### PR TITLE
Add support for aborting jobs

### DIFF
--- a/docs/api-protected/HubManager.md
+++ b/docs/api-protected/HubManager.md
@@ -6,7 +6,7 @@
 Manages the lifecycle of jobs.
 
 **Kind**: global class  
-**Emits**: <code>[managerStarted](HubManager.md#HubManager+event_managerStarted)</code>, <code>[jobCreated](HubManager.md#HubManager+event_jobCreated)</code>, <code>[jobStarted](HubManager.md#HubManager+event_jobStarted)</code>, <code>[jobForked](HubManager.md#HubManager+event_jobForked)</code>, <code>[jobProgress](HubManager.md#HubManager+event_jobProgress)</code>, <code>[jobSuccess](HubManager.md#HubManager+event_jobSuccess)</code>, <code>[jobFailure](HubManager.md#HubManager+event_jobFailure)</code>, <code>[jobTerminate](HubManager.md#HubManager+event_jobTerminate)</code>  
+**Emits**: <code>[managerStarted](HubManager.md#HubManager+event_managerStarted)</code>, <code>[jobCreated](HubManager.md#HubManager+event_jobCreated)</code>, <code>[jobStarted](HubManager.md#HubManager+event_jobStarted)</code>, <code>[jobForked](HubManager.md#HubManager+event_jobForked)</code>, <code>[jobProgress](HubManager.md#HubManager+event_jobProgress)</code>, <code>[jobSuccess](HubManager.md#HubManager+event_jobSuccess)</code>, <code>[jobFailure](HubManager.md#HubManager+event_jobFailure)</code>, <code>[jobAbort](HubManager.md#HubManager+event_jobAbort)</code>, <code>[jobTerminate](HubManager.md#HubManager+event_jobTerminate)</code>  
 
 * [HubManager](HubManager.md#HubManager)
     * [new HubManager(options)](HubManager.md#HubManager)
@@ -32,6 +32,7 @@ Manages the lifecycle of jobs.
     * ["jobProgress" (trackedJob, progress)](HubManager.md#HubManager+event_jobProgress)
     * ["jobSuccess" (trackedJob, result)](HubManager.md#HubManager+event_jobSuccess)
     * ["jobFailure" (trackedJob, error)](HubManager.md#HubManager+event_jobFailure)
+    * ["jobAbort" (trackedJob)](HubManager.md#HubManager+event_jobAbort)
 
 <a name="new_HubManager_new"></a>
 
@@ -291,4 +292,15 @@ Fires when a job reports failure.
 | --- | --- |
 | trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
 | error | <code>Error</code> | 
+
+<a name="HubManager+event_jobAbort"></a>
+
+### "jobAbort" (trackedJob)
+Fires when a job is attempted to be aborted.
+
+**Kind**: event emitted by <code>[HubManager](HubManager.md#HubManager)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
 

--- a/docs/api-protected/JobAbortedError.md
+++ b/docs/api-protected/JobAbortedError.md
@@ -1,0 +1,28 @@
+# [jobhub Extended API](README.md): Class:
+
+<a name="JobAbortedError"></a>
+
+## JobAbortedError ⇐ <code>Error</code>
+A JobAbortedError object indicates that a forked job has been aborted by calling [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: global class  
+**Extends:** <code>Error</code>  
+**Category**: errors  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| jobName | <code>string</code> | The name of the job. |
+| jobId | <code>string</code> | The job's ID. |
+| abortReason | <code>string</code> | TODO |
+
+<a name="new_JobAbortedError_new"></a>
+
+### new JobAbortedError(jobName, jobId, abortReason)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jobName | <code>string</code> | The name of the job. |
+| jobId | <code>string</code> | The job's ID. |
+| abortReason | <code>string</code> | TODO |
+

--- a/docs/api-protected/JobRunArg.md
+++ b/docs/api-protected/JobRunArg.md
@@ -14,6 +14,7 @@ to provide information about the job and facilitate communicate progress/success
     * [.resolve(result)](JobRunArg.md#JobRunArg+resolve)
     * [.reject(error)](JobRunArg.md#JobRunArg+reject)
     * [.sendProgress(progress)](JobRunArg.md#JobRunArg+sendProgress) ⇒ <code>Promise</code>
+    * [.onAbort(handler)](JobRunArg.md#JobRunArg+onAbort)
 
 <a name="JobRunArg+jobId"></a>
 
@@ -75,4 +76,20 @@ Send progress data.
 | Param | Type |
 | --- | --- |
 | progress | <code>\*</code> | 
+
+<a name="JobRunArg+onAbort"></a>
+
+### jobRunArg.onAbort(handler)
+Add a listener for an abort event.
+
+**Kind**: instance method of <code>[JobRunArg](JobRunArg.md#JobRunArg)</code>  
+**See**
+
+- [TrackedJob#abort](TrackedJob.md#TrackedJob+abort)
+- [TrackedJob#event:jobAbort](TrackedJob.md#TrackedJob+event_jobAbort)
+
+
+| Param | Type |
+| --- | --- |
+| handler | <code>function</code> | 
 

--- a/docs/api-protected/JobWorker.md
+++ b/docs/api-protected/JobWorker.md
@@ -2,12 +2,14 @@
 
 <a name="JobWorker"></a>
 
-## JobWorker
+## JobWorker ⇐ <code>EventEmitter</code>
 Responsible for running the job in the forked worker process.
 
 **Kind**: global class  
+**Extends:** <code>EventEmitter</code>  
+**Emits**: <code>[jobAbort](JobWorker.md#JobWorker+event_jobAbort)</code>  
 
-* [JobWorker](JobWorker.md#JobWorker)
+* [JobWorker](JobWorker.md#JobWorker) ⇐ <code>EventEmitter</code>
     * [new JobWorker(jobId, jobName, params, options)](JobWorker.md#JobWorker)
     * [.jobId](JobWorker.md#JobWorker+jobId) : <code>string</code>
     * [.jobName](JobWorker.md#JobWorker+jobName) : <code>string</code>
@@ -25,6 +27,8 @@ Responsible for running the job in the forked worker process.
     * [.handleSuccess(result)](JobWorker.md#JobWorker+handleSuccess) ⇒ <code>Promise</code>
     * [.handleError(err)](JobWorker.md#JobWorker+handleError) ⇒ <code>Promise</code>
     * [.handleProgress(progress)](JobWorker.md#JobWorker+handleProgress) ⇒ <code>Promise</code>
+    * [.handleAbort()](JobWorker.md#JobWorker+handleAbort)
+    * ["jobAbort"](JobWorker.md#JobWorker+event_jobAbort)
 
 <a name="new_JobWorker_new"></a>
 
@@ -154,3 +158,18 @@ Called when the job sends progress.
 | --- | --- |
 | progress | <code>\*</code> | 
 
+<a name="JobWorker+handleAbort"></a>
+
+### jobWorker.handleAbort()
+Called when the JobWorker is notified of an abort.
+
+Emits a [JobWorker#event:jobAbort](JobWorker.md#JobWorker+event_jobAbort) only if [JobWorker#running](JobWorker.md#JobWorker+running) is true.
+
+**Kind**: instance method of <code>[JobWorker](JobWorker.md#JobWorker)</code>  
+**Access:** protected  
+<a name="JobWorker+event_jobAbort"></a>
+
+### "jobAbort"
+Fires when the job is told to abort.
+
+**Kind**: event emitted by <code>[JobWorker](JobWorker.md#JobWorker)</code>  

--- a/docs/api-protected/JobWorkerIPC.md
+++ b/docs/api-protected/JobWorkerIPC.md
@@ -33,6 +33,8 @@ receiving configuration and sending events via an IPC messages.
     * [.getSupportedSyncMiddleware()](JobWorkerIPC.md#JobWorker+getSupportedSyncMiddleware) ⇒ <code>Array.&lt;string&gt;</code>
     * [.loadJob()](JobWorkerIPC.md#JobWorker+loadJob) ⇒ <code>Promise</code>
     * [.buildJobArg(resolve, reject)](JobWorkerIPC.md#JobWorker+buildJobArg) ⇒ <code>[JobRunArg](JobRunArg.md#JobRunArg)</code>
+    * [.handleAbort()](JobWorkerIPC.md#JobWorker+handleAbort)
+    * ["jobAbort"](JobWorkerIPC.md#JobWorker+event_jobAbort)
 
 <a name="JobWorkerIPC+payloadMessageTimeout"></a>
 
@@ -229,3 +231,18 @@ Build the "job" argument for [JobConfig#run](JobConfig.md#JobConfig+run).
 | resolve | <code>function</code> | 
 | reject | <code>function</code> | 
 
+<a name="JobWorker+handleAbort"></a>
+
+### jobWorkerIPC.handleAbort()
+Called when the JobWorker is notified of an abort.
+
+Emits a [JobWorker#event:jobAbort](JobWorker.md#JobWorker+event_jobAbort) only if [JobWorker#running](JobWorker.md#JobWorker+running) is true.
+
+**Kind**: instance method of <code>[JobWorkerIPC](JobWorkerIPC.md#JobWorkerIPC)</code>  
+**Access:** protected  
+<a name="JobWorker+event_jobAbort"></a>
+
+### "jobAbort"
+Fires when the job is told to abort.
+
+**Kind**: event emitted by <code>[JobWorkerIPC](JobWorkerIPC.md#JobWorkerIPC)</code>  

--- a/docs/api-protected/JobWorkerIPCMediator.md
+++ b/docs/api-protected/JobWorkerIPCMediator.md
@@ -12,6 +12,7 @@ Manages a job's forked process during it's normal lifecycle.
     * [new JobWorkerIPCMediator(trackedJob)](JobWorkerIPCMediator.md#JobWorkerIPCMediator)
     * [.childProcess](JobWorkerIPCMediator.md#JobWorkerIPCMediator+childProcess) : <code>ChildProcess</code> &#124; <code>null</code>
     * [.trackedJob](JobWorkerIPCMediator.md#JobWorkerMediator+trackedJob) : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.forked](JobWorkerIPCMediator.md#JobWorkerMediator+forked) : <code>boolean</code>
     * [.started](JobWorkerIPCMediator.md#JobWorkerMediator+started) : <code>boolean</code>
     * [.settled](JobWorkerIPCMediator.md#JobWorkerMediator+settled) : <code>boolean</code>
     * [.exited](JobWorkerIPCMediator.md#JobWorkerMediator+exited) : <code>boolean</code>
@@ -26,6 +27,7 @@ Manages a job's forked process during it's normal lifecycle.
     * [.startWorker()](JobWorkerIPCMediator.md#JobWorkerMediator+startWorker) ⇒ <code>Promise</code>
     * [.stopMediation()](JobWorkerIPCMediator.md#JobWorkerMediator+stopMediation) ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * *[.terminate([forceKill])](JobWorkerIPCMediator.md#JobWorkerMediator+terminate)*
+    * *[.sendAbortMessage()](JobWorkerIPCMediator.md#JobWorkerMediator+sendAbortMessage)*
     * *[.execWorker()](JobWorkerIPCMediator.md#JobWorkerMediator+execWorker) ⇒ <code>void</code> &#124; <code>Promise</code>*
     * [.initStartupTimeout()](JobWorkerIPCMediator.md#JobWorkerMediator+initStartupTimeout)
     * [.beginStartupTimeout(timeout)](JobWorkerIPCMediator.md#JobWorkerMediator+beginStartupTimeout)
@@ -55,9 +57,17 @@ Manages a job's forked process during it's normal lifecycle.
 
 ### jobWorkerIPCMediator.trackedJob : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
 **Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+<a name="JobWorkerMediator+forked"></a>
+
+### jobWorkerIPCMediator.forked : <code>boolean</code>
+Set to true once [JobWorkerMediator#execWorker](JobWorkerMediator.md#JobWorkerMediator+execWorker) resolves.
+
+**Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
 <a name="JobWorkerMediator+started"></a>
 
 ### jobWorkerIPCMediator.started : <code>boolean</code>
+Set to true once [JobWorkerMediator#handleStartupConfirmation](JobWorkerMediator.md#JobWorkerMediator+handleStartupConfirmation) is called.
+
 **Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
 <a name="JobWorkerMediator+settled"></a>
 
@@ -145,6 +155,7 @@ Handle an 'exit' ChildProcess event.
 Execute job's worker process and begin mediation of communication with it.
 
 **Kind**: instance method of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+**Fulfil**: <code>void</code> Resolves after the worker process has been forked.  
 <a name="JobWorkerMediator+stopMediation"></a>
 
 ### jobWorkerIPCMediator.stopMediation() ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
@@ -164,6 +175,15 @@ Terminate the job's worker process.
 | --- | --- | --- |
 | [forceKill] | <code>boolean</code> | <code>false</code> | 
 
+<a name="JobWorkerMediator+sendAbortMessage"></a>
+
+### *jobWorkerIPCMediator.sendAbortMessage()*
+Notify the job's worker process that the job is being aborted.
+
+Should not be called directly. Instead use [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance abstract method of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+**Overrides:** <code>[sendAbortMessage](JobWorkerMediator.md#JobWorkerMediator+sendAbortMessage)</code>  
 <a name="JobWorkerMediator+execWorker"></a>
 
 ### *jobWorkerIPCMediator.execWorker() ⇒ <code>void</code> &#124; <code>Promise</code>*

--- a/docs/api-protected/JobWorkerMediator.md
+++ b/docs/api-protected/JobWorkerMediator.md
@@ -12,6 +12,7 @@ Responsible for forking the job's child worker process and mediating communicati
 * [JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator) ⇐ <code>EventEmitter</code>
     * [new JobWorkerMediator(trackedJob)](JobWorkerMediator.md#JobWorkerMediator)
     * [.trackedJob](JobWorkerMediator.md#JobWorkerMediator+trackedJob) : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.forked](JobWorkerMediator.md#JobWorkerMediator+forked) : <code>boolean</code>
     * [.started](JobWorkerMediator.md#JobWorkerMediator+started) : <code>boolean</code>
     * [.settled](JobWorkerMediator.md#JobWorkerMediator+settled) : <code>boolean</code>
     * [.exited](JobWorkerMediator.md#JobWorkerMediator+exited) : <code>boolean</code>
@@ -19,6 +20,7 @@ Responsible for forking the job's child worker process and mediating communicati
     * [.startWorker()](JobWorkerMediator.md#JobWorkerMediator+startWorker) ⇒ <code>Promise</code>
     * [.stopMediation()](JobWorkerMediator.md#JobWorkerMediator+stopMediation) ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * *[.terminate([forceKill])](JobWorkerMediator.md#JobWorkerMediator+terminate)*
+    * *[.sendAbortMessage()](JobWorkerMediator.md#JobWorkerMediator+sendAbortMessage)*
     * *[.execWorker()](JobWorkerMediator.md#JobWorkerMediator+execWorker) ⇒ <code>void</code> &#124; <code>Promise</code>*
     * [.initStartupTimeout()](JobWorkerMediator.md#JobWorkerMediator+initStartupTimeout)
     * [.beginStartupTimeout(timeout)](JobWorkerMediator.md#JobWorkerMediator+beginStartupTimeout)
@@ -45,9 +47,17 @@ Responsible for forking the job's child worker process and mediating communicati
 
 ### jobWorkerMediator.trackedJob : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
 **Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
+<a name="JobWorkerMediator+forked"></a>
+
+### jobWorkerMediator.forked : <code>boolean</code>
+Set to true once [JobWorkerMediator#execWorker](JobWorkerMediator.md#JobWorkerMediator+execWorker) resolves.
+
+**Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+started"></a>
 
 ### jobWorkerMediator.started : <code>boolean</code>
+Set to true once [JobWorkerMediator#handleStartupConfirmation](JobWorkerMediator.md#JobWorkerMediator+handleStartupConfirmation) is called.
+
 **Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+settled"></a>
 
@@ -67,6 +77,7 @@ Responsible for forking the job's child worker process and mediating communicati
 Execute job's worker process and begin mediation of communication with it.
 
 **Kind**: instance method of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
+**Fulfil**: <code>void</code> Resolves after the worker process has been forked.  
 <a name="JobWorkerMediator+stopMediation"></a>
 
 ### jobWorkerMediator.stopMediation() ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
@@ -84,6 +95,14 @@ Terminate the job's worker process.
 | --- | --- | --- |
 | [forceKill] | <code>boolean</code> | <code>false</code> | 
 
+<a name="JobWorkerMediator+sendAbortMessage"></a>
+
+### *jobWorkerMediator.sendAbortMessage()*
+Notify the job's worker process that the job is being aborted.
+
+Should not be called directly. Instead use [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance abstract method of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+execWorker"></a>
 
 ### *jobWorkerMediator.execWorker() ⇒ <code>void</code> &#124; <code>Promise</code>*

--- a/docs/api-protected/README.md
+++ b/docs/api-protected/README.md
@@ -29,7 +29,7 @@ to provide information about the job and facilitate communicate progress/success
 <dt><a href="JobConfigStore.md#JobConfigStore">JobConfigStore</a></dt>
 <dd><p>Manages registered job config.</p>
 </dd>
-<dt><a href="JobWorker.md#JobWorker">JobWorker</a></dt>
+<dt><a href="JobWorker.md#JobWorker">JobWorker</a> ⇐ <code>EventEmitter</code></dt>
 <dd><p>Responsible for running the job in the forked worker process.</p>
 </dd>
 <dt><a href="JobWorkerIPC.md#JobWorkerIPC">JobWorkerIPC</a> ⇐ <code><a href="JobWorker.md#JobWorker">JobWorker</a></code></dt>
@@ -74,6 +74,9 @@ an invalid value for a specific property.</p>
 </dd>
 <dt><a href="JobForkError.md#JobForkError">JobForkError</a> ⇐ <code>Error</code></dt>
 <dd><p>A JobForkError object indicates that a forked job encountered an error.</p>
+</dd>
+<dt><a href="JobAbortedError.md#JobAbortedError">JobAbortedError</a> ⇐ <code>Error</code></dt>
+<dd><p>A JobAbortedError object indicates that a forked job has been aborted by calling <a href="TrackedJob.md#TrackedJob+abort">TrackedJob#abort</a>.</p>
 </dd>
 <dt><a href="InvalidJobParamError.md#InvalidJobParamError">InvalidJobParamError</a> ⇐ <code>Error</code></dt>
 <dd><p>A InvalidJobParamError object indicates that params

--- a/docs/api-protected/TrackedJob.md
+++ b/docs/api-protected/TrackedJob.md
@@ -7,7 +7,7 @@ Tracks a job that has not yet completed.
 
 **Kind**: global class  
 **Extends:** <code>EventEmitter</code>  
-**Emits**: <code>[jobStarted](TrackedJob.md#TrackedJob+event_jobStarted)</code>, <code>[jobForked](TrackedJob.md#TrackedJob+event_jobForked)</code>, <code>[jobProgress](TrackedJob.md#TrackedJob+event_jobProgress)</code>, <code>[jobSuccess](TrackedJob.md#TrackedJob+event_jobSuccess)</code>, <code>[jobFailure](TrackedJob.md#TrackedJob+event_jobFailure)</code>  
+**Emits**: <code>[jobStarted](TrackedJob.md#TrackedJob+event_jobStarted)</code>, <code>[jobForked](TrackedJob.md#TrackedJob+event_jobForked)</code>, <code>[jobProgress](TrackedJob.md#TrackedJob+event_jobProgress)</code>, <code>[jobSuccess](TrackedJob.md#TrackedJob+event_jobSuccess)</code>, <code>[jobFailure](TrackedJob.md#TrackedJob+event_jobFailure)</code>, <code>[jobAbort](TrackedJob.md#TrackedJob+event_jobAbort)</code>  
 
 * [TrackedJob](TrackedJob.md#TrackedJob) ⇐ <code>EventEmitter</code>
     * [new TrackedJob(manager, jobId, jobConfig, [params])](TrackedJob.md#TrackedJob)
@@ -18,6 +18,8 @@ Tracks a job that has not yet completed.
     * [.jobConfig](TrackedJob.md#TrackedJob+jobConfig) : <code>[JobConfig](JobConfig.md#JobConfig)</code>
     * [.params](TrackedJob.md#TrackedJob+params) : <code>\*</code>
     * [.isRunning](TrackedJob.md#TrackedJob+isRunning) : <code>boolean</code>
+    * [.aborted](TrackedJob.md#TrackedJob+aborted) : <code>boolean</code>
+    * [.abortReason](TrackedJob.md#TrackedJob+abortReason) : <code>null</code> &#124; <code>string</code>
     * [.promise](TrackedJob.md#TrackedJob+promise) : <code>null</code> &#124; <code>Promise</code>
     * [.workerMediator](TrackedJob.md#TrackedJob+workerMediator) : <code>null</code> &#124; <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * [.result](TrackedJob.md#TrackedJob+result) : <code>\*</code>
@@ -26,12 +28,14 @@ Tracks a job that has not yet completed.
     * [.then()](TrackedJob.md#TrackedJob+then) ⇒ <code>Promise</code>
     * [.catch()](TrackedJob.md#TrackedJob+catch) ⇒ <code>Promise</code>
     * [.run()](TrackedJob.md#TrackedJob+run) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.abort([reason])](TrackedJob.md#TrackedJob+abort) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
     * [.reEmitTo(eventEmitter)](TrackedJob.md#TrackedJob+reEmitTo) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
     * ["jobStarted"](TrackedJob.md#TrackedJob+event_jobStarted)
     * ["jobForked"](TrackedJob.md#TrackedJob+event_jobForked)
     * ["jobProgress" (progress)](TrackedJob.md#TrackedJob+event_jobProgress)
     * ["jobSuccess" (result)](TrackedJob.md#TrackedJob+event_jobSuccess)
     * ["jobFailure" (error)](TrackedJob.md#TrackedJob+event_jobFailure)
+    * ["jobAbort" (abortReason)](TrackedJob.md#TrackedJob+event_jobAbort)
 
 <a name="new_TrackedJob_new"></a>
 
@@ -94,6 +98,20 @@ Parameters for this job passed from [HubManager#queueJob](HubManager.md#HubManag
 Set to `true` once [JobConfig#run](JobConfig.md#JobConfig+run) is called and false after the job succeeds or fails.
 
 **Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+aborted"></a>
+
+### trackedJob.aborted : <code>boolean</code>
+Indicates that [TrackedJob#abort](TrackedJob.md#TrackedJob+abort) has been called, but does not mean the job has actually aborted.
+
+See [TrackedJob#abort](TrackedJob.md#TrackedJob+abort) for detail.
+
+**Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+abortReason"></a>
+
+### trackedJob.abortReason : <code>null</code> &#124; <code>string</code>
+User-specified message for the reason the job was aborted, set by [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
 <a name="TrackedJob+promise"></a>
 
 ### trackedJob.promise : <code>null</code> &#124; <code>Promise</code>
@@ -147,6 +165,43 @@ Only usable after [TrackedJob#run](TrackedJob.md#TrackedJob+run) is called.
 Start the job, if it has not already started.
 
 **Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+abort"></a>
+
+### trackedJob.abort([reason]) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+
+The abort will not actually happen if:
+
+* [JobConfig#validate](JobConfig.md#JobConfig+validate) already threw an error for invalid params.
+* [JobConfig#quickRun](JobConfig.md#JobConfig+quickRun) already called [JobRunArg#resolve](JobRunArg.md#JobRunArg+resolve)/[JobRunArg#reject](JobRunArg.md#JobRunArg+reject) or it threw an error.
+* [TrackedJob#workerMediator](TrackedJob.md#TrackedJob+workerMediator) already received a success or error message from the job's worker process.
+
+To determine if a job was actually aborted either:
+
+* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is true,
+add a catch to [TrackedJob#promise](TrackedJob.md#TrackedJob+promise) or listen for the [TrackedJob#event:jobFailure](TrackedJob.md#TrackedJob+event_jobFailure) event, and
+check if the error is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
+
+    – or –
+
+* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is false,
+check if [TrackedJob#error](TrackedJob.md#TrackedJob+error) is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
+
+Calling this method does nothing if [TrackedJob#running](TrackedJob#running) is false
+or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) is already true.
+
+**Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+**See**
+
+- [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted)
+- [TrackedJob#abortReason](TrackedJob.md#TrackedJob+abortReason)
+- [TrackedJob#sendAbortMessage](TrackedJob#sendAbortMessage)
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [reason] | <code>string</code> | <code>&quot;No reason specified&quot;</code> | Message for why the job was aborted. |
+
 <a name="TrackedJob+reEmitTo"></a>
 
 ### trackedJob.reEmitTo(eventEmitter) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
@@ -203,4 +258,15 @@ Fires when the tracked job reports failure.
 | Param | Type |
 | --- | --- |
 | error | <code>Error</code> | 
+
+<a name="TrackedJob+event_jobAbort"></a>
+
+### "jobAbort" (abortReason)
+Fires when the tracked job is attempted to be aborted.
+
+**Kind**: event emitted by <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+
+| Param | Type |
+| --- | --- |
+| abortReason | <code>string</code> | 
 

--- a/docs/api-protected/TrackedJob.md
+++ b/docs/api-protected/TrackedJob.md
@@ -171,7 +171,7 @@ Start the job, if it has not already started.
 <a name="TrackedJob+abort"></a>
 
 ### trackedJob.abort([reason]) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
-Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+Attempt to abort a job. Calling this method does not mean the job will actually be aborted.
 
 The abort will not actually happen if:
 
@@ -181,17 +181,17 @@ The abort will not actually happen if:
 
 To determine if a job was actually aborted either:
 
-* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is true,
+* If [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled) is `false`,
 add a catch to [TrackedJob#promise](TrackedJob.md#TrackedJob+promise) or listen for the [TrackedJob#event:jobFailure](TrackedJob.md#TrackedJob+event_jobFailure) event, and
 check if the error is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
 
     – or –
 
-* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is false,
+* If [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled) is `true`,
 check if [TrackedJob#error](TrackedJob.md#TrackedJob+error) is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
 
-Calling this method does nothing if [TrackedJob#running](TrackedJob#running) is false
-or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) is already true.
+Calling this method does nothing if either [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled)
+or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) are already `true`.
 
 **Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
 **See**

--- a/docs/api/HubManager.md
+++ b/docs/api/HubManager.md
@@ -6,7 +6,7 @@
 Manages the lifecycle of jobs.
 
 **Kind**: global class  
-**Emits**: <code>[managerStarted](HubManager.md#HubManager+event_managerStarted)</code>, <code>[jobCreated](HubManager.md#HubManager+event_jobCreated)</code>, <code>[jobStarted](HubManager.md#HubManager+event_jobStarted)</code>, <code>[jobForked](HubManager.md#HubManager+event_jobForked)</code>, <code>[jobProgress](HubManager.md#HubManager+event_jobProgress)</code>, <code>[jobSuccess](HubManager.md#HubManager+event_jobSuccess)</code>, <code>[jobFailure](HubManager.md#HubManager+event_jobFailure)</code>, <code>[jobTerminate](HubManager.md#HubManager+event_jobTerminate)</code>  
+**Emits**: <code>[managerStarted](HubManager.md#HubManager+event_managerStarted)</code>, <code>[jobCreated](HubManager.md#HubManager+event_jobCreated)</code>, <code>[jobStarted](HubManager.md#HubManager+event_jobStarted)</code>, <code>[jobForked](HubManager.md#HubManager+event_jobForked)</code>, <code>[jobProgress](HubManager.md#HubManager+event_jobProgress)</code>, <code>[jobSuccess](HubManager.md#HubManager+event_jobSuccess)</code>, <code>[jobFailure](HubManager.md#HubManager+event_jobFailure)</code>, <code>[jobAbort](HubManager.md#HubManager+event_jobAbort)</code>, <code>[jobTerminate](HubManager.md#HubManager+event_jobTerminate)</code>  
 
 * [HubManager](HubManager.md#HubManager)
     * [new HubManager(options)](HubManager.md#HubManager)
@@ -29,6 +29,7 @@ Manages the lifecycle of jobs.
     * ["jobProgress" (trackedJob, progress)](HubManager.md#HubManager+event_jobProgress)
     * ["jobSuccess" (trackedJob, result)](HubManager.md#HubManager+event_jobSuccess)
     * ["jobFailure" (trackedJob, error)](HubManager.md#HubManager+event_jobFailure)
+    * ["jobAbort" (trackedJob)](HubManager.md#HubManager+event_jobAbort)
 
 <a name="new_HubManager_new"></a>
 
@@ -255,4 +256,15 @@ Fires when a job reports failure.
 | --- | --- |
 | trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
 | error | <code>Error</code> | 
+
+<a name="HubManager+event_jobAbort"></a>
+
+### "jobAbort" (trackedJob)
+Fires when a job is attempted to be aborted.
+
+**Kind**: event emitted by <code>[HubManager](HubManager.md#HubManager)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
 

--- a/docs/api/JobAbortedError.md
+++ b/docs/api/JobAbortedError.md
@@ -1,0 +1,28 @@
+# [jobhub API](README.md): Class:
+
+<a name="JobAbortedError"></a>
+
+## JobAbortedError ⇐ <code>Error</code>
+A JobAbortedError object indicates that a forked job has been aborted by calling [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: global class  
+**Extends:** <code>Error</code>  
+**Category**: errors  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| jobName | <code>string</code> | The name of the job. |
+| jobId | <code>string</code> | The job's ID. |
+| abortReason | <code>string</code> | TODO |
+
+<a name="new_JobAbortedError_new"></a>
+
+### new JobAbortedError(jobName, jobId, abortReason)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jobName | <code>string</code> | The name of the job. |
+| jobId | <code>string</code> | The job's ID. |
+| abortReason | <code>string</code> | TODO |
+

--- a/docs/api/JobRunArg.md
+++ b/docs/api/JobRunArg.md
@@ -14,6 +14,7 @@ to provide information about the job and facilitate communicate progress/success
     * [.resolve(result)](JobRunArg.md#JobRunArg+resolve)
     * [.reject(error)](JobRunArg.md#JobRunArg+reject)
     * [.sendProgress(progress)](JobRunArg.md#JobRunArg+sendProgress) ⇒ <code>Promise</code>
+    * [.onAbort(handler)](JobRunArg.md#JobRunArg+onAbort)
 
 <a name="JobRunArg+jobId"></a>
 
@@ -75,4 +76,20 @@ Send progress data.
 | Param | Type |
 | --- | --- |
 | progress | <code>\*</code> | 
+
+<a name="JobRunArg+onAbort"></a>
+
+### jobRunArg.onAbort(handler)
+Add a listener for an abort event.
+
+**Kind**: instance method of <code>[JobRunArg](JobRunArg.md#JobRunArg)</code>  
+**See**
+
+- [TrackedJob#abort](TrackedJob.md#TrackedJob+abort)
+- [TrackedJob#event:jobAbort](TrackedJob.md#TrackedJob+event_jobAbort)
+
+
+| Param | Type |
+| --- | --- |
+| handler | <code>function</code> | 
 

--- a/docs/api/JobWorker.md
+++ b/docs/api/JobWorker.md
@@ -2,12 +2,14 @@
 
 <a name="JobWorker"></a>
 
-## JobWorker
+## JobWorker ⇐ <code>EventEmitter</code>
 Responsible for running the job in the forked worker process.
 
 **Kind**: global class  
+**Extends:** <code>EventEmitter</code>  
+**Emits**: <code>[jobAbort](JobWorker.md#JobWorker+event_jobAbort)</code>  
 
-* [JobWorker](JobWorker.md#JobWorker)
+* [JobWorker](JobWorker.md#JobWorker) ⇐ <code>EventEmitter</code>
     * [new JobWorker(jobId, jobName, params, options)](JobWorker.md#JobWorker)
     * [.jobId](JobWorker.md#JobWorker+jobId) : <code>string</code>
     * [.jobName](JobWorker.md#JobWorker+jobName) : <code>string</code>
@@ -18,6 +20,7 @@ Responsible for running the job in the forked worker process.
     * [.middleware](JobWorker.md#JobWorker+middleware) : <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
     * [.jobs](JobWorker.md#JobWorker+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
     * [.start()](JobWorker.md#JobWorker+start) ⇒ <code>Promise</code>
+    * ["jobAbort"](JobWorker.md#JobWorker+event_jobAbort)
 
 <a name="new_JobWorker_new"></a>
 
@@ -74,3 +77,9 @@ Set to a Promise the first time [JobWorker#start](JobWorker.md#JobWorker+start) 
 Starts the job, loads job config, validates params and executes [JobConfig#run](JobConfig.md#JobConfig+run).
 
 **Kind**: instance method of <code>[JobWorker](JobWorker.md#JobWorker)</code>  
+<a name="JobWorker+event_jobAbort"></a>
+
+### "jobAbort"
+Fires when the job is told to abort.
+
+**Kind**: event emitted by <code>[JobWorker](JobWorker.md#JobWorker)</code>  

--- a/docs/api/JobWorkerIPC.md
+++ b/docs/api/JobWorkerIPC.md
@@ -21,6 +21,7 @@ receiving configuration and sending events via an IPC messages.
     * [.jobs](JobWorkerIPC.md#JobWorker+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
     * [.init()](JobWorkerIPC.md#JobWorkerIPC+init) ⇒ <code>Promise</code>
     * [.start()](JobWorkerIPC.md#JobWorker+start) ⇒ <code>Promise</code>
+    * ["jobAbort"](JobWorkerIPC.md#JobWorker+event_jobAbort)
 
 <a name="JobWorkerIPC+payloadMessageTimeout"></a>
 
@@ -90,3 +91,9 @@ Overrides [JobWorker#init](JobWorker#init) to first request the following to be 
 Starts the job, loads job config, validates params and executes [JobConfig#run](JobConfig.md#JobConfig+run).
 
 **Kind**: instance method of <code>[JobWorkerIPC](JobWorkerIPC.md#JobWorkerIPC)</code>  
+<a name="JobWorker+event_jobAbort"></a>
+
+### "jobAbort"
+Fires when the job is told to abort.
+
+**Kind**: event emitted by <code>[JobWorkerIPC](JobWorkerIPC.md#JobWorkerIPC)</code>  

--- a/docs/api/JobWorkerIPCMediator.md
+++ b/docs/api/JobWorkerIPCMediator.md
@@ -12,6 +12,7 @@ Manages a job's forked process during it's normal lifecycle.
     * [new JobWorkerIPCMediator(trackedJob)](JobWorkerIPCMediator.md#JobWorkerIPCMediator)
     * [.childProcess](JobWorkerIPCMediator.md#JobWorkerIPCMediator+childProcess) : <code>ChildProcess</code> &#124; <code>null</code>
     * [.trackedJob](JobWorkerIPCMediator.md#JobWorkerMediator+trackedJob) : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.forked](JobWorkerIPCMediator.md#JobWorkerMediator+forked) : <code>boolean</code>
     * [.started](JobWorkerIPCMediator.md#JobWorkerMediator+started) : <code>boolean</code>
     * [.settled](JobWorkerIPCMediator.md#JobWorkerMediator+settled) : <code>boolean</code>
     * [.exited](JobWorkerIPCMediator.md#JobWorkerMediator+exited) : <code>boolean</code>
@@ -19,6 +20,7 @@ Manages a job's forked process during it's normal lifecycle.
     * [.startWorker()](JobWorkerIPCMediator.md#JobWorkerMediator+startWorker) ⇒ <code>Promise</code>
     * [.stopMediation()](JobWorkerIPCMediator.md#JobWorkerMediator+stopMediation) ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * *[.terminate([forceKill])](JobWorkerIPCMediator.md#JobWorkerMediator+terminate)*
+    * *[.sendAbortMessage()](JobWorkerIPCMediator.md#JobWorkerMediator+sendAbortMessage)*
     * ["jobProgress" (progress)](JobWorkerIPCMediator.md#JobWorkerMediator+event_jobProgress)
     * ["jobSuccess" (result)](JobWorkerIPCMediator.md#JobWorkerMediator+event_jobSuccess)
     * ["jobFailure" (error)](JobWorkerIPCMediator.md#JobWorkerMediator+event_jobFailure)
@@ -40,9 +42,17 @@ Manages a job's forked process during it's normal lifecycle.
 
 ### jobWorkerIPCMediator.trackedJob : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
 **Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+<a name="JobWorkerMediator+forked"></a>
+
+### jobWorkerIPCMediator.forked : <code>boolean</code>
+Set to true once [JobWorkerMediator#execWorker](JobWorkerMediator#execWorker) resolves.
+
+**Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
 <a name="JobWorkerMediator+started"></a>
 
 ### jobWorkerIPCMediator.started : <code>boolean</code>
+Set to true once [JobWorkerMediator#handleStartupConfirmation](JobWorkerMediator#handleStartupConfirmation) is called.
+
 **Kind**: instance property of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
 <a name="JobWorkerMediator+settled"></a>
 
@@ -63,6 +73,7 @@ Manages a job's forked process during it's normal lifecycle.
 Execute job's worker process and begin mediation of communication with it.
 
 **Kind**: instance method of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+**Fulfil**: <code>void</code> Resolves after the worker process has been forked.  
 <a name="JobWorkerMediator+stopMediation"></a>
 
 ### jobWorkerIPCMediator.stopMediation() ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
@@ -82,6 +93,15 @@ Terminate the job's worker process.
 | --- | --- | --- |
 | [forceKill] | <code>boolean</code> | <code>false</code> | 
 
+<a name="JobWorkerMediator+sendAbortMessage"></a>
+
+### *jobWorkerIPCMediator.sendAbortMessage()*
+Notify the job's worker process that the job is being aborted.
+
+Should not be called directly. Instead use [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance abstract method of <code>[JobWorkerIPCMediator](JobWorkerIPCMediator.md#JobWorkerIPCMediator)</code>  
+**Overrides:** <code>[sendAbortMessage](JobWorkerMediator.md#JobWorkerMediator+sendAbortMessage)</code>  
 <a name="JobWorkerMediator+event_jobProgress"></a>
 
 ### "jobProgress" (progress)

--- a/docs/api/JobWorkerMediator.md
+++ b/docs/api/JobWorkerMediator.md
@@ -12,6 +12,7 @@ Responsible for forking the job's child worker process and mediating communicati
 * [JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator) ⇐ <code>EventEmitter</code>
     * [new JobWorkerMediator(trackedJob)](JobWorkerMediator.md#JobWorkerMediator)
     * [.trackedJob](JobWorkerMediator.md#JobWorkerMediator+trackedJob) : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.forked](JobWorkerMediator.md#JobWorkerMediator+forked) : <code>boolean</code>
     * [.started](JobWorkerMediator.md#JobWorkerMediator+started) : <code>boolean</code>
     * [.settled](JobWorkerMediator.md#JobWorkerMediator+settled) : <code>boolean</code>
     * [.exited](JobWorkerMediator.md#JobWorkerMediator+exited) : <code>boolean</code>
@@ -19,6 +20,7 @@ Responsible for forking the job's child worker process and mediating communicati
     * [.startWorker()](JobWorkerMediator.md#JobWorkerMediator+startWorker) ⇒ <code>Promise</code>
     * [.stopMediation()](JobWorkerMediator.md#JobWorkerMediator+stopMediation) ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * *[.terminate([forceKill])](JobWorkerMediator.md#JobWorkerMediator+terminate)*
+    * *[.sendAbortMessage()](JobWorkerMediator.md#JobWorkerMediator+sendAbortMessage)*
     * ["jobProgress" (progress)](JobWorkerMediator.md#JobWorkerMediator+event_jobProgress)
     * ["jobSuccess" (result)](JobWorkerMediator.md#JobWorkerMediator+event_jobSuccess)
     * ["jobFailure" (error)](JobWorkerMediator.md#JobWorkerMediator+event_jobFailure)
@@ -36,9 +38,17 @@ Responsible for forking the job's child worker process and mediating communicati
 
 ### jobWorkerMediator.trackedJob : <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
 **Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
+<a name="JobWorkerMediator+forked"></a>
+
+### jobWorkerMediator.forked : <code>boolean</code>
+Set to true once [JobWorkerMediator#execWorker](JobWorkerMediator#execWorker) resolves.
+
+**Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+started"></a>
 
 ### jobWorkerMediator.started : <code>boolean</code>
+Set to true once [JobWorkerMediator#handleStartupConfirmation](JobWorkerMediator#handleStartupConfirmation) is called.
+
 **Kind**: instance property of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+settled"></a>
 
@@ -58,6 +68,7 @@ Responsible for forking the job's child worker process and mediating communicati
 Execute job's worker process and begin mediation of communication with it.
 
 **Kind**: instance method of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
+**Fulfil**: <code>void</code> Resolves after the worker process has been forked.  
 <a name="JobWorkerMediator+stopMediation"></a>
 
 ### jobWorkerMediator.stopMediation() ⇒ <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
@@ -75,6 +86,14 @@ Terminate the job's worker process.
 | --- | --- | --- |
 | [forceKill] | <code>boolean</code> | <code>false</code> | 
 
+<a name="JobWorkerMediator+sendAbortMessage"></a>
+
+### *jobWorkerMediator.sendAbortMessage()*
+Notify the job's worker process that the job is being aborted.
+
+Should not be called directly. Instead use [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance abstract method of <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>  
 <a name="JobWorkerMediator+event_jobProgress"></a>
 
 ### "jobProgress" (progress)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -29,7 +29,7 @@ to provide information about the job and facilitate communicate progress/success
 <dt><a href="JobConfigStore.md#JobConfigStore">JobConfigStore</a></dt>
 <dd><p>Manages registered job config.</p>
 </dd>
-<dt><a href="JobWorker.md#JobWorker">JobWorker</a></dt>
+<dt><a href="JobWorker.md#JobWorker">JobWorker</a> ⇐ <code>EventEmitter</code></dt>
 <dd><p>Responsible for running the job in the forked worker process.</p>
 </dd>
 <dt><a href="JobWorkerIPC.md#JobWorkerIPC">JobWorkerIPC</a> ⇐ <code><a href="JobWorker.md#JobWorker">JobWorker</a></code></dt>
@@ -74,6 +74,9 @@ an invalid value for a specific property.</p>
 </dd>
 <dt><a href="JobForkError.md#JobForkError">JobForkError</a> ⇐ <code>Error</code></dt>
 <dd><p>A JobForkError object indicates that a forked job encountered an error.</p>
+</dd>
+<dt><a href="JobAbortedError.md#JobAbortedError">JobAbortedError</a> ⇐ <code>Error</code></dt>
+<dd><p>A JobAbortedError object indicates that a forked job has been aborted by calling <a href="TrackedJob.md#TrackedJob+abort">TrackedJob#abort</a>.</p>
 </dd>
 <dt><a href="InvalidJobParamError.md#InvalidJobParamError">InvalidJobParamError</a> ⇐ <code>Error</code></dt>
 <dd><p>A InvalidJobParamError object indicates that params

--- a/docs/api/TrackedJob.md
+++ b/docs/api/TrackedJob.md
@@ -7,7 +7,7 @@ Tracks a job that has not yet completed.
 
 **Kind**: global class  
 **Extends:** <code>EventEmitter</code>  
-**Emits**: <code>[jobStarted](TrackedJob.md#TrackedJob+event_jobStarted)</code>, <code>[jobForked](TrackedJob.md#TrackedJob+event_jobForked)</code>, <code>[jobProgress](TrackedJob.md#TrackedJob+event_jobProgress)</code>, <code>[jobSuccess](TrackedJob.md#TrackedJob+event_jobSuccess)</code>, <code>[jobFailure](TrackedJob.md#TrackedJob+event_jobFailure)</code>  
+**Emits**: <code>[jobStarted](TrackedJob.md#TrackedJob+event_jobStarted)</code>, <code>[jobForked](TrackedJob.md#TrackedJob+event_jobForked)</code>, <code>[jobProgress](TrackedJob.md#TrackedJob+event_jobProgress)</code>, <code>[jobSuccess](TrackedJob.md#TrackedJob+event_jobSuccess)</code>, <code>[jobFailure](TrackedJob.md#TrackedJob+event_jobFailure)</code>, <code>[jobAbort](TrackedJob.md#TrackedJob+event_jobAbort)</code>  
 
 * [TrackedJob](TrackedJob.md#TrackedJob) ⇐ <code>EventEmitter</code>
     * [new TrackedJob(manager, jobId, jobConfig, [params])](TrackedJob.md#TrackedJob)
@@ -18,6 +18,8 @@ Tracks a job that has not yet completed.
     * [.jobConfig](TrackedJob.md#TrackedJob+jobConfig) : <code>[JobConfig](JobConfig.md#JobConfig)</code>
     * [.params](TrackedJob.md#TrackedJob+params) : <code>\*</code>
     * [.isRunning](TrackedJob.md#TrackedJob+isRunning) : <code>boolean</code>
+    * [.aborted](TrackedJob.md#TrackedJob+aborted) : <code>boolean</code>
+    * [.abortReason](TrackedJob.md#TrackedJob+abortReason) : <code>null</code> &#124; <code>string</code>
     * [.promise](TrackedJob.md#TrackedJob+promise) : <code>null</code> &#124; <code>Promise</code>
     * [.workerMediator](TrackedJob.md#TrackedJob+workerMediator) : <code>null</code> &#124; <code>[JobWorkerMediator](JobWorkerMediator.md#JobWorkerMediator)</code>
     * [.result](TrackedJob.md#TrackedJob+result) : <code>\*</code>
@@ -26,12 +28,14 @@ Tracks a job that has not yet completed.
     * [.then()](TrackedJob.md#TrackedJob+then) ⇒ <code>Promise</code>
     * [.catch()](TrackedJob.md#TrackedJob+catch) ⇒ <code>Promise</code>
     * [.run()](TrackedJob.md#TrackedJob+run) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+    * [.abort([reason])](TrackedJob.md#TrackedJob+abort) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
     * [.reEmitTo(eventEmitter)](TrackedJob.md#TrackedJob+reEmitTo) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
     * ["jobStarted"](TrackedJob.md#TrackedJob+event_jobStarted)
     * ["jobForked"](TrackedJob.md#TrackedJob+event_jobForked)
     * ["jobProgress" (progress)](TrackedJob.md#TrackedJob+event_jobProgress)
     * ["jobSuccess" (result)](TrackedJob.md#TrackedJob+event_jobSuccess)
     * ["jobFailure" (error)](TrackedJob.md#TrackedJob+event_jobFailure)
+    * ["jobAbort" (abortReason)](TrackedJob.md#TrackedJob+event_jobAbort)
 
 <a name="new_TrackedJob_new"></a>
 
@@ -94,6 +98,20 @@ Parameters for this job passed from [HubManager#queueJob](HubManager.md#HubManag
 Set to `true` once [JobConfig#run](JobConfig.md#JobConfig+run) is called and false after the job succeeds or fails.
 
 **Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+aborted"></a>
+
+### trackedJob.aborted : <code>boolean</code>
+Indicates that [TrackedJob#abort](TrackedJob.md#TrackedJob+abort) has been called, but does not mean the job has actually aborted.
+
+See [TrackedJob#abort](TrackedJob.md#TrackedJob+abort) for detail.
+
+**Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+abortReason"></a>
+
+### trackedJob.abortReason : <code>null</code> &#124; <code>string</code>
+User-specified message for the reason the job was aborted, set by [TrackedJob#abort](TrackedJob.md#TrackedJob+abort).
+
+**Kind**: instance property of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
 <a name="TrackedJob+promise"></a>
 
 ### trackedJob.promise : <code>null</code> &#124; <code>Promise</code>
@@ -147,6 +165,43 @@ Only usable after [TrackedJob#run](TrackedJob.md#TrackedJob+run) is called.
 Start the job, if it has not already started.
 
 **Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+<a name="TrackedJob+abort"></a>
+
+### trackedJob.abort([reason]) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
+Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+
+The abort will not actually happen if:
+
+* [JobConfig#validate](JobConfig.md#JobConfig+validate) already threw an error for invalid params.
+* [JobConfig#quickRun](JobConfig.md#JobConfig+quickRun) already called [JobRunArg#resolve](JobRunArg.md#JobRunArg+resolve)/[JobRunArg#reject](JobRunArg.md#JobRunArg+reject) or it threw an error.
+* [TrackedJob#workerMediator](TrackedJob.md#TrackedJob+workerMediator) already received a success or error message from the job's worker process.
+
+To determine if a job was actually aborted either:
+
+* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is true,
+add a catch to [TrackedJob#promise](TrackedJob.md#TrackedJob+promise) or listen for the [TrackedJob#event:jobFailure](TrackedJob.md#TrackedJob+event_jobFailure) event, and
+check if the error is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
+
+    – or –
+
+* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is false,
+check if [TrackedJob#error](TrackedJob.md#TrackedJob+error) is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
+
+Calling this method does nothing if [TrackedJob#running](TrackedJob#running) is false
+or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) is already true.
+
+**Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+**See**
+
+- [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted)
+- [TrackedJob#abortReason](TrackedJob.md#TrackedJob+abortReason)
+- [TrackedJob#sendAbortMessage](TrackedJob#sendAbortMessage)
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [reason] | <code>string</code> | <code>&quot;No reason specified&quot;</code> | Message for why the job was aborted. |
+
 <a name="TrackedJob+reEmitTo"></a>
 
 ### trackedJob.reEmitTo(eventEmitter) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
@@ -203,4 +258,15 @@ Fires when the tracked job reports failure.
 | Param | Type |
 | --- | --- |
 | error | <code>Error</code> | 
+
+<a name="TrackedJob+event_jobAbort"></a>
+
+### "jobAbort" (abortReason)
+Fires when the tracked job is attempted to be aborted.
+
+**Kind**: event emitted by <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
+
+| Param | Type |
+| --- | --- |
+| abortReason | <code>string</code> | 
 

--- a/docs/api/TrackedJob.md
+++ b/docs/api/TrackedJob.md
@@ -171,7 +171,7 @@ Start the job, if it has not already started.
 <a name="TrackedJob+abort"></a>
 
 ### trackedJob.abort([reason]) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>
-Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+Attempt to abort a job. Calling this method does not mean the job will actually be aborted.
 
 The abort will not actually happen if:
 
@@ -181,17 +181,17 @@ The abort will not actually happen if:
 
 To determine if a job was actually aborted either:
 
-* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is true,
+* If [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled) is `false`,
 add a catch to [TrackedJob#promise](TrackedJob.md#TrackedJob+promise) or listen for the [TrackedJob#event:jobFailure](TrackedJob.md#TrackedJob+event_jobFailure) event, and
 check if the error is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
 
     – or –
 
-* If [TrackedJob#isRunning](TrackedJob.md#TrackedJob+isRunning) is false,
+* If [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled) is `true`,
 check if [TrackedJob#error](TrackedJob.md#TrackedJob+error) is an instance of [JobAbortedError](JobAbortedError.md#JobAbortedError).
 
-Calling this method does nothing if [TrackedJob#running](TrackedJob#running) is false
-or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) is already true.
+Calling this method does nothing if either [TrackedJob#isSettled](TrackedJob.md#TrackedJob+isSettled)
+or [TrackedJob#aborted](TrackedJob.md#TrackedJob+aborted) are already `true`.
 
 **Kind**: instance method of <code>[TrackedJob](TrackedJob.md#TrackedJob)</code>  
 **See**

--- a/examples/abort-jobs/index.js
+++ b/examples/abort-jobs/index.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-console */
+
+var path = require('path');
+var jobhub = require('../../lib/index');
+
+var verbose = process.argv.indexOf('-v') >= 0;
+
+var hub = new jobhub.HubManager({
+	jobsModulePath: path.resolve(__dirname, 'jobs.js')
+}).start();
+
+if (verbose) {
+	require('../util').logManagerEvents(hub);
+}
+
+var trackedJobA = hub.queueJob('stallingValidation');
+trackedJobA.catch(function(err) {
+	console.log('[MANAGER] stallingValidation failed (' + err.name + '): ' + err.message);
+});
+setTimeout(function() {
+	trackedJobA.abort('Took too long!');
+}, 1000);
+
+var trackedJobB = hub.queueJob('stallingQuickRun');
+trackedJobB.catch(function(err) {
+	console.log('[MANAGER] stallingQuickRun failed (' + err.name + '): ' + err.message);
+});
+setTimeout(function() {
+	trackedJobB.abort('Took too long!');
+}, 1000);
+
+var trackedJobC = hub.queueJob('stallingRun');
+trackedJobC.catch(function(err) {
+	console.log('[MANAGER] stallingRun failed (' + err.name + '): ' + err.message);
+});
+trackedJobC.on('jobForked', function() {
+	setTimeout(function() {
+		trackedJobC.abort('Took too long!');
+	}, 1000);
+});

--- a/examples/abort-jobs/jobs.js
+++ b/examples/abort-jobs/jobs.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-console,valid-jsdoc */
+
+exports.stallingValidation = {
+	validate: function() {
+		console.log('[JOB] Running validate for "stallingValidation"');
+
+		return new Promise(function(){
+			// Never resolves
+		});
+	},
+	run: function(job) {
+
+	}
+}
+
+exports.stallingQuickRun = {
+	quickRun: function(job) {
+		console.log('[JOB] Running quickRun for "stallingQuickRun"');
+
+		job.onAbort(function() {
+			console.log('[JOB] Uh oh! "stallingQuickRun" notified of an abort! Better do some cleanup...');
+		});
+
+		// Never resolves
+	},
+	run: function(job) {
+
+	}
+};
+
+exports.stallingRun = function(job) {
+	console.log('[JOB] Running "stallingRun" in process pid:' + process.pid);
+
+	job.onAbort(function() {
+		console.log('[JOB] Uh oh! "stallingRun" notified of an abort! Better do some cleanup...');
+
+		// Reject to shutdown worker process immediately.
+		job.reject(new Error());
+	});
+
+	// Never resolves
+};

--- a/lib/HubManager.js
+++ b/lib/HubManager.js
@@ -65,6 +65,7 @@ module.exports = HubManager;
  * @fires HubManager#jobProgress
  * @fires HubManager#jobSuccess
  * @fires HubManager#jobFailure
+ * @fires HubManager#jobAbort
  * @fires HubManager#jobTerminate
  */
 function HubManager(options) {
@@ -484,6 +485,13 @@ HubManager.prototype._emitJobTerminate = function(trackedJob, isForceKill) {
  * @event HubManager#jobFailure
  * @param {TrackedJob} trackedJob
  * @param {Error} error
+ */
+
+/**
+ * Fires when a job is attempted to be aborted.
+ *
+ * @event HubManager#jobAbort
+ * @param {TrackedJob} trackedJob
  */
 
 /**

--- a/lib/HubManager.js
+++ b/lib/HubManager.js
@@ -386,7 +386,7 @@ HubManager.prototype.handleSettledJob = function(trackedJob) {
  * @param {TrackedJob} trackedJob
  */
 HubManager.prototype.queueForTermination = function(trackedJob) {
-	if (trackedJob.workerMediator && trackedJob.workerMediator.started && !trackedJob.workerMediator.exited) {
+	if (trackedJob.workerMediator && trackedJob.workerMediator.forked && !trackedJob.workerMediator.exited) {
 		var termTimeout = this.options.terminationSIGTERMTimeout;
 		var killTimeout = this.options.terminationSIGKILLTimeout;
 

--- a/lib/JobConfigStore.js
+++ b/lib/JobConfigStore.js
@@ -237,3 +237,12 @@ JobConfigStore.prototype.getJobConfig = function(jobName) {
  * @see {@link TrackedJob#event:jobProgress}
  * @see {@link HubManager#event:jobProgress}
  */
+
+/**
+ * Add a listener for an abort event.
+ *
+ * @function JobRunArg#onAbort
+ * @param {function} handler
+ * @see {@link TrackedJob#abort}
+ * @see {@link TrackedJob#event:jobAbort}
+ */

--- a/lib/JobWorker.js
+++ b/lib/JobWorker.js
@@ -12,10 +12,12 @@ module.exports = JobWorker;
  * @classdesc Responsible for running the job in the forked worker process.
  *
  * @class
+ * @augments {EventEmitter}
  * @param {string} jobId
  * @param {string} jobName
  * @param {*} params
  * @param {object|HubManagerOptions} options
+ * @fires JobWorker#jobAbort
  */
 function JobWorker(jobId, jobName, params, options) {
 	EventEmitter.call(this);
@@ -205,14 +207,22 @@ JobWorker.prototype.buildJobArg = function(resolve, reject) {
 	return this.middleware.runSyncMiddleware(
 		constants.MIDDLEWARE_WORKER_BUILD_JOB_ARG,
 		this,
-		[this.jobId, this.params, resolve, reject, this.handleProgress.bind(this)],
-		function(jobId, params, resolve, reject, sendProgress) {
+		[
+			this.jobId,
+			this.params,
+			resolve,
+			reject,
+			this.handleProgress.bind(this),
+			this.once.bind(this, constants.EVENT_JOB_ABORT)
+		],
+		function(jobId, params, resolve, reject, sendProgress, onAbort) {
 			return {
 				jobId: jobId,
 				params: params,
 				resolve: resolve,
 				reject: reject,
-				sendProgress: sendProgress
+				sendProgress: sendProgress,
+				onAbort: onAbort
 			};
 		}
 	);
@@ -249,4 +259,26 @@ JobWorker.prototype.handleError = function(err) { // eslint-disable-line no-unus
  */
 JobWorker.prototype.handleProgress = function(progress) { // eslint-disable-line no-unused-vars
 	return Promise.resolve();
+};
+
+/**
+ * Called when the JobWorker is notified of an abort.
+ *
+ * Emits a {@link JobWorker#event:jobAbort} only if {@link JobWorker#running} is true.
+ *
+ * @protected
+ */
+JobWorker.prototype.handleAbort = function() {
+	if (this.running) {
+		this._emitJobAbort();
+	}
+};
+
+/**
+ * Fires when the job is told to abort.
+ *
+ * @event JobWorker#jobAbort
+ */
+JobWorker.prototype._emitJobAbort = function() {
+	this.emit(constants.EVENT_JOB_ABORT);
 };

--- a/lib/JobWorkerIPC.js
+++ b/lib/JobWorkerIPC.js
@@ -77,12 +77,21 @@ JobWorkerIPC.prototype.init = function() {
 JobWorkerIPC.prototype.requestIPCPayload = function() {
 	return new Promise(function(resolve, reject) {
 		var timeoutId = setTimeout(function() {
+			this.removeListener(constants.EVENT_JOB_ABORT, abortListener);
 			reject(new Error('Timeout for receiving job payload IPC message'));
-		}, this.payloadMessageTimeout).unref();
+		}.bind(this), this.payloadMessageTimeout).unref();
+
+		// Temporarily listen for an abort message which may be received instead of the payload.
+		this.once(constants.EVENT_JOB_ABORT, abortListener);
+		function abortListener() {
+			clearTimeout(timeoutId);
+			reject(new Error('Received abort message before job payload'));
+		}
 
 		// Listen for messages from manager process
 		this.once('ipc-message::' + constants.JOB_MESSAGE_PAYLOAD, function(payload) {
 			clearTimeout(timeoutId);
+			this.removeListener(constants.EVENT_JOB_ABORT, abortListener);
 			resolve(payload);
 		});
 
@@ -92,10 +101,11 @@ JobWorkerIPC.prototype.requestIPCPayload = function() {
 		}, function(err) {
 			if (err) {
 				clearTimeout(timeoutId);
+				this.removeListener(constants.EVENT_JOB_ABORT, abortListener);
 				err.message = 'Failed to send job startup confirmation: ' + err.message;
 				reject(err);
 			}
-		});
+		}.bind(this));
 	}.bind(this));
 };
 
@@ -121,6 +131,9 @@ JobWorkerIPC.prototype.attachIPCChecks = function() {
 	else {
 		process.on('disconnect', this.handleIPCDisconnect = this.handleIPCDisconnect.bind(this));
 		process.on('message', this.handleIPCMessage = this.handleIPCMessage.bind(this));
+
+		// Listen for abort message.
+		this.on('ipc-message::' + constants.JOB_MESSAGE_ABORT, this.handleAbort);
 	}
 };
 

--- a/lib/JobWorkerIPCMediator.js
+++ b/lib/JobWorkerIPCMediator.js
@@ -243,7 +243,7 @@ JobWorkerIPCMediator.prototype.handleChildExit = function() {
 };
 
 JobWorkerIPCMediator.prototype.terminate = function(forceKill) {
-	if (this.childProcess && this.started && !this.exited) {
+	if (this.childProcess && this.forked && !this.exited) {
 		if (forceKill) {
 			this.childProcess.kill('SIGKILL');
 		}

--- a/lib/JobWorkerIPCMediator.js
+++ b/lib/JobWorkerIPCMediator.js
@@ -21,6 +21,14 @@ function JobWorkerIPCMediator(trackedJob) {
 	 */
 	this.childProcess = null;
 
+	/**
+	 * Indicates that the abort message should be sent once the startup confirmation is received.
+	 *
+	 * @private
+	 * @type {boolean}
+	 */
+	this._sendAbortMessage = false;
+
 	JobWorkerMediator.call(this, trackedJob);
 }
 
@@ -111,6 +119,14 @@ JobWorkerIPCMediator.prototype.addChildListeners = function() {
  */
 JobWorkerIPCMediator.prototype.handleStartupConfirmation = function() {
 	JobWorkerMediator.prototype.handleStartupConfirmation.call(this);
+
+	// If was aborted before receiving the startup confirmation,
+	// send the abort message now that we know the child process
+	// is listening for messages.
+	if (this._sendAbortMessage) {
+		this.sendAbortMessage();
+		return;
+	}
 
 	this.childProcess.send({
 		type: constants.JOB_MESSAGE_PAYLOAD,
@@ -251,6 +267,18 @@ JobWorkerIPCMediator.prototype.terminate = function(forceKill) {
 			// TODO: Send terminate message if still connected
 			this.childProcess.kill('SIGTERM');
 		}
+	}
+};
+
+JobWorkerIPCMediator.prototype.sendAbortMessage = function() {
+	// Send the message later if not started, as the child process may not be listening to messages yet.
+	if (!this.started) {
+		this._sendAbortMessage = true;
+	}
+	else if (this.childProcess && this.childProcess.connected) {
+		this.childProcess.send({
+			type: constants.JOB_MESSAGE_ABORT
+		});
 	}
 };
 

--- a/lib/JobWorkerMediator.js
+++ b/lib/JobWorkerMediator.js
@@ -26,6 +26,15 @@ function JobWorkerMediator(trackedJob) {
 	this.trackedJob = trackedJob;
 
 	/**
+	 * Set to true once {@link JobWorkerMediator#execWorker} resolves.
+	 *
+	 * @member {boolean} JobWorkerMediator#forked
+	 */
+	this.forked = false;
+
+	/**
+	 * Set to true once {@link JobWorkerMediator#handleStartupConfirmation} is called.
+	 *
 	 * @member {boolean} JobWorkerMediator#started
 	 */
 	this.started = false;
@@ -52,6 +61,7 @@ inherits(JobWorkerMediator, EventEmitter);
 /**
  * Execute job's worker process and begin mediation of communication with it.
  *
+ * @fulfil {void} Resolves after the worker process has been forked.
  * @returns {Promise}
  */
 JobWorkerMediator.prototype.startWorker = function() {
@@ -60,7 +70,7 @@ JobWorkerMediator.prototype.startWorker = function() {
 		return this.execWorker();
 	}.bind(this))
 		.then(function() {
-			this.started = true;
+			this.forked = true;
 		}.bind(this), function(err) {
 			this.stopMediation();
 			throw err;
@@ -133,6 +143,7 @@ JobWorkerMediator.prototype.beginStartupTimeout = function(timeout) {
  */
 JobWorkerMediator.prototype.handleStartupConfirmation = function() {
 	clearTimeout(this._startupTimerId);
+	this.started = true;
 };
 
 /**

--- a/lib/JobWorkerMediator.js
+++ b/lib/JobWorkerMediator.js
@@ -98,6 +98,17 @@ JobWorkerMediator.prototype.terminate = function(forceKill) { // eslint-disable-
 };
 
 /**
+ * Notify the job's worker process that the job is being aborted.
+ *
+ * Should not be called directly. Instead use {@link TrackedJob#abort}.
+ *
+ * @abstract
+ */
+JobWorkerMediator.prototype.sendAbortMessage = function() {
+	throw new Error('JobWorkerMediator#sendAbortMessage is abstract and must be overridden');
+};
+
+/**
  * Execute the worker process and begin mediating communication with it.
  *
  * @abstract

--- a/lib/TrackedJob.js
+++ b/lib/TrackedJob.js
@@ -1,6 +1,7 @@
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var constants = require('./constants');
+var errors = require('./errors');
 var util = require('./util');
 var JobWorkerIPCMediator = require('./JobWorkerIPCMediator');
 
@@ -20,6 +21,7 @@ module.exports = TrackedJob;
  * @fires TrackedJob#jobProgress
  * @fires TrackedJob#jobSuccess
  * @fires TrackedJob#jobFailure
+ * @fires TrackedJob#jobAbort
  */
 function TrackedJob(manager, jobId, jobConfig, params) {
 	EventEmitter.call(this);
@@ -80,6 +82,31 @@ function TrackedJob(manager, jobId, jobConfig, params) {
 	 * @member {boolean} TrackedJob#isRunning
 	 */
 	this.isRunning = false;
+
+	/**
+	 * Indicates that {@link TrackedJob#abort} has been called, but does not mean the job has actually aborted.
+	 *
+	 * See {@link TrackedJob#abort} for detail.
+	 *
+	 * @member {boolean} TrackedJob#aborted
+	 */
+	this.aborted = false;
+
+	/**
+	 * User-specified message for the reason the job was aborted, set by {@link TrackedJob#abort}.
+	 *
+	 * @member {null|string} TrackedJob#abortReason
+	 */
+	this.abortReason = null;
+
+	/**
+	 * Error instance that will be used to reject the job.
+	 *
+	 * @private
+	 * @type {null|JobAbortedError}
+	 * @see {@link TrackedJob#abort}
+	 */
+	this._abortError = null;
 
 	/**
 	 * Set to a Promise after run() is called, and is fulfilled once the job succeeds or fails.
@@ -167,7 +194,12 @@ TrackedJob.prototype.run = function() {
 				this._emitJobStarted();
 
 				// Validate job params
-				return util.validateJobParams(this.jobConfig, this.params);
+				return new Promise(function(resolve, reject) {
+					this._setAbortWatcher(reject);
+
+					util.validateJobParams(this.jobConfig, this.params)
+						.then(resolve, reject);
+				}.bind(this));
 			}.bind(this))
 			.then(function() {
 				// Run the job
@@ -204,17 +236,90 @@ TrackedJob.prototype.run = function() {
 			.then(function(result) {
 				this.isRunning = false;
 				this.result = result;
+				this._abortError = null;
+				this.removeAllListeners('___INTERNAL_JOB_ABORT___');
 				this._emitJobSuccess(result);
 				return result;
 			}.bind(this), function(err) {
 				this.isRunning = false;
 				this.error = err;
+				this._abortError = null;
+				this.removeAllListeners('___INTERNAL_JOB_ABORT___');
 				this._emitJobFailure(err);
 				throw err;
 			}.bind(this));
 	}
 
 	return this;
+};
+
+/**
+ * Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+ *
+ * The abort will not actually happen if:
+ *
+ * * {@link JobConfig#validate} already threw an error for invalid params.
+ * * {@link JobConfig#quickRun} already called {@link JobRunArg#resolve}/{@link JobRunArg#reject} or it threw an error.
+ * * {@link TrackedJob#workerMediator} already received a success or error message from the job's worker process.
+ *
+ * To determine if a job was actually aborted either:
+ *
+ * * If {@link TrackedJob#isRunning} is true,
+ * add a catch to {@link TrackedJob#promise} or listen for the {@link TrackedJob#event:jobFailure} event, and
+ * check if the error is an instance of {@link JobAbortedError}.
+ *
+ *     – or –
+ *
+ * * If {@link TrackedJob#isRunning} is false,
+ * check if {@link TrackedJob#error} is an instance of {@link JobAbortedError}.
+ *
+ * Calling this method does nothing if {@link TrackedJob#running} is false
+ * or {@link TrackedJob#aborted} is already true.
+ *
+ * @param {string} [reason=No reason specified] - Message for why the job was aborted.
+ * @returns {TrackedJob}
+ * @see {@link TrackedJob#aborted}
+ * @see {@link TrackedJob#abortReason}
+ * @see {@link TrackedJob#sendAbortMessage}
+ */
+TrackedJob.prototype.abort = function(reason) {
+	if (this.isRunning && !this.aborted) {
+		this.aborted = true;
+		this.abortReason = reason || 'No reason specified';
+		this._abortError = new errors.JobAbortedError(this.jobConfig.jobName, this.jobId, this.abortReason);
+
+		this.emit('___INTERNAL_JOB_ABORT___');
+		this._emitAbort(this.abortReason);
+	}
+
+	return this;
+};
+
+/**
+ * @private
+ * @param {function} [cb]
+ */
+TrackedJob.prototype._setAbortWatcher = function(cb) {
+	// Check if already aborted.
+	if (this.aborted) {
+		throw this._abortError;
+	}
+
+	// Remove existing callback.
+	this.removeAllListeners('___INTERNAL_JOB_ABORT___');
+
+	// Add the new callback.
+	if (cb) {
+		this.once('___INTERNAL_JOB_ABORT___', function() {
+			// Use setImmediate to give some time for resolved/rejected promises.
+			setImmediate(function() {
+				// Check if error still exists, just in case the job was resolved/rejected before the callback executed.
+				if (this._abortError) {
+					cb(this._abortError);
+				}
+			}.bind(this));
+		}.bind(this));
+	}
 };
 
 /**
@@ -227,6 +332,8 @@ TrackedJob.prototype.run = function() {
  */
 TrackedJob.prototype._attemptQuickRun = function(resolve, reject, next) {
 	if (this.jobConfig.quickRun) {
+		this._setAbortWatcher(reject);
+
 		// Run params through stringification to normalize
 		var cleanedParams = typeof this.params === 'undefined'
 			? this.params
@@ -245,13 +352,16 @@ TrackedJob.prototype._attemptQuickRun = function(resolve, reject, next) {
 			}.bind(this));
 		}.bind(this);
 
+		var onAbort = this.once.bind(this, constants.EVENT_JOB_ABORT);
+
 		// TODO: Clean resolve value through JSON.stringify
 		var job = {
 			jobId: this.jobId,
 			params: cleanedParams,
 			resolve: resolve,
 			reject: reject,
-			sendProgress: sendProgress
+			sendProgress: sendProgress,
+			onAbort: onAbort
 		};
 
 		this.jobConfig.quickRun(job, next);
@@ -276,6 +386,7 @@ TrackedJob.prototype._startWorker = function() {
 	}.bind(this);
 
 	return new Promise(function(resolve, reject) {
+		this._setAbortWatcher(reject);
 
 		// Create the mediator which manages communication to the worker process
 		this.workerMediator = this.manager.middleware.runSyncMiddleware(
@@ -291,6 +402,16 @@ TrackedJob.prototype._startWorker = function() {
 			.on(constants.EVENT_JOB_SUCCESS, resolve)
 			.on(constants.EVENT_JOB_FAILURE, reject)
 			.on(constants.EVENT_JOB_PROGRESS, sendProgress);
+
+		// Set abort watcher again so an abort message is sent to the child worker.
+		this._setAbortWatcher(function(err) {
+			// Only abort if mediator has not yet received success/failure events, since
+			// it's possible that event callbacks could call abort.
+			if (!this.workerMediator.settled) {
+				this.workerMediator.sendAbortMessage();
+				reject(err);
+			}
+		}.bind(this));
 
 		// Start the worker process
 		this.workerMediator.startWorker()
@@ -314,6 +435,7 @@ TrackedJob.prototype.reEmitTo = function(eventEmitter) {
 	this.on(constants.EVENT_JOB_PROGRESS, eventEmitter.emit.bind(eventEmitter, constants.EVENT_JOB_PROGRESS, this));
 	this.on(constants.EVENT_JOB_SUCCESS, eventEmitter.emit.bind(eventEmitter, constants.EVENT_JOB_SUCCESS, this));
 	this.on(constants.EVENT_JOB_FAILURE, eventEmitter.emit.bind(eventEmitter, constants.EVENT_JOB_FAILURE, this));
+	this.on(constants.EVENT_JOB_ABORT, eventEmitter.emit.bind(eventEmitter, constants.EVENT_JOB_ABORT, this));
 	return this;
 };
 
@@ -363,6 +485,16 @@ TrackedJob.prototype._emitJobSuccess = function(result) {
  */
 TrackedJob.prototype._emitJobFailure = function(error) {
 	this.emit(constants.EVENT_JOB_FAILURE, error);
+};
+
+/**
+ * Fires when the tracked job is attempted to be aborted.
+ *
+ * @event TrackedJob#jobAbort
+ * @param {string} abortReason
+ */
+TrackedJob.prototype._emitAbort = function(abortReason) {
+	this.emit(constants.EVENT_JOB_ABORT, abortReason);
 };
 
 /**

--- a/lib/TrackedJob.js
+++ b/lib/TrackedJob.js
@@ -283,7 +283,7 @@ TrackedJob.prototype.run = function() {
 };
 
 /**
- * Attempt to abort a running job. Calling this method does not mean the job will actually be aborted.
+ * Attempt to abort a job. Calling this method does not mean the job will actually be aborted.
  *
  * The abort will not actually happen if:
  *
@@ -293,17 +293,17 @@ TrackedJob.prototype.run = function() {
  *
  * To determine if a job was actually aborted either:
  *
- * * If {@link TrackedJob#isRunning} is true,
+ * * If {@link TrackedJob#isSettled} is `false`,
  * add a catch to {@link TrackedJob#promise} or listen for the {@link TrackedJob#event:jobFailure} event, and
  * check if the error is an instance of {@link JobAbortedError}.
  *
  *     – or –
  *
- * * If {@link TrackedJob#isRunning} is false,
+ * * If {@link TrackedJob#isSettled} is `true`,
  * check if {@link TrackedJob#error} is an instance of {@link JobAbortedError}.
  *
- * Calling this method does nothing if {@link TrackedJob#running} is false
- * or {@link TrackedJob#aborted} is already true.
+ * Calling this method does nothing if either {@link TrackedJob#isSettled}
+ * or {@link TrackedJob#aborted} are already `true`.
  *
  * @param {string} [reason=No reason specified] - Message for why the job was aborted.
  * @returns {TrackedJob}
@@ -312,13 +312,28 @@ TrackedJob.prototype.run = function() {
  * @see {@link TrackedJob#sendAbortMessage}
  */
 TrackedJob.prototype.abort = function(reason) {
-	if (this.isRunning && !this.aborted) {
+	if (!this.isSettled && !this.aborted) {
 		this.aborted = true;
 		this.abortReason = reason || 'No reason specified';
 		this._abortError = new errors.JobAbortedError(this.jobConfig.jobName, this.jobId, this.abortReason);
 
-		this.emit('___INTERNAL_JOB_ABORT___');
-		this._emitAbort(this.abortReason);
+		if (this.isRunning) {
+			this.emit('___INTERNAL_JOB_ABORT___');
+			this._emitAbort(this.abortReason);
+		}
+		else {
+			this._emitAbort(this.abortReason);
+			this.isSettled = true;
+			this.error = this._abortError;
+			this._abortError = null;
+			this.removeAllListeners('___INTERNAL_JOB_ABORT___');
+
+			// Wrap jobFailure event to catch errors similar to TrackedJob#run
+			this.promise = new Promise(function(resolve, reject) {
+				this._emitJobFailure(this.error);
+				reject(this.error);
+			}.bind(this));
+		}
 	}
 
 	return this;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,6 +14,7 @@ exports.EVENT_JOB_FORKED = 'jobForked';
 exports.EVENT_JOB_SUCCESS = 'jobSuccess';
 exports.EVENT_JOB_FAILURE = 'jobFailure';
 exports.EVENT_JOB_PROGRESS = 'jobProgress';
+exports.EVENT_JOB_ABORT = 'jobAbort';
 exports.EVENT_JOB_EXIT = 'jobExit';
 exports.EVENT_JOB_TERMINATE = 'jobTerminate';
 
@@ -22,6 +23,7 @@ exports.JOB_MESSAGE_PAYLOAD = '__JOBHUB_WORKER_PAYLOAD__';
 exports.JOB_MESSAGE_SUCCESS = '__JOBHUB_WORKER_SUCCESS__';
 exports.JOB_MESSAGE_ERROR = '__JOBHUB_WORKER_ERROR__';
 exports.JOB_MESSAGE_PROGRESS = '__JOBHUB_WORKER_PROGRESS__';
+exports.JOB_MESSAGE_ABORT = '__JOBHUB_WORKER_ABORT__';
 
 exports.MIDDLEWARE_LOAD_JOBS = 'loadJobs';
 exports.MIDDLEWARE_CREATE_JOB = 'createJob';

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,6 +9,7 @@ exports.InvalidJobConfigError = InvalidJobConfigError;
 //exports.InvalidWorkerPayloadError = InvalidWorkerPayloadError;
 exports.InvalidUniqueKeyError = InvalidUniqueKeyError;
 exports.JobForkError = JobForkError;
+exports.JobAbortedError = JobAbortedError;
 exports.InvalidJobParamError = InvalidJobParamError;
 exports.UnsupportedMiddlewareTypeError = UnsupportedMiddlewareTypeError;
 exports.JobWorkerHandlerError = JobWorkerHandlerError;
@@ -197,6 +198,35 @@ function JobForkError(message, jobName, jobId, options) {
 	}
 }
 JobForkError.prototype = Object.create(Error.prototype);
+
+/**
+ * @classdesc A JobAbortedError object indicates that a forked job has been aborted by calling {@link TrackedJob#abort}.
+ *
+ * @class
+ * @static
+ * @category errors
+ * @augments Error
+ * @param {string} jobName - The name of the job.
+ * @param {string} jobId - The job's ID.
+ * @param {string} abortReason - TODO
+ * @property {string} jobName - The name of the job.
+ * @property {string} jobId - The job's ID.
+ * @property {string} abortReason - TODO
+ */
+function JobAbortedError(jobName, jobId, abortReason) {
+	if (Error.captureStackTrace && !isStrict) {
+		Error.captureStackTrace(this, arguments.callee);
+	}
+	else {
+		this.stack = (new Error()).stack;
+	}
+	this.name = 'JobAbortedError';
+	this.message = 'Job aborted: ' + abortReason;
+	this.jobName = jobName;
+	this.jobId = jobId;
+	this.abortReason = abortReason;
+}
+JobAbortedError.prototype = Object.create(Error.prototype);
 
 /**
  * @classdesc A InvalidJobParamError object indicates that params

--- a/test/specs/JobWorkerMediator.spec.js
+++ b/test/specs/JobWorkerMediator.spec.js
@@ -76,6 +76,16 @@ describe('JobWorkerMediator', function() {
 				if (!(err instanceof Error) || err.message !== 'JobWorkerMediator#terminate is abstract and must be overridden') {
 					throw err;
 				}
+			}),
+			new Promise(function(resolve, reject) {
+				mediator.sendAbortMessage();
+				reject(new Error('Expected to throw error for JobWorkerMediator#sendAbortMessage'))
+			}).then(function() {
+				throw new Error('Expected to not resolve for JobWorkerMediator#sendAbortMessage');
+			}, function(err) {
+				if (!(err instanceof Error) || err.message !== 'JobWorkerMediator#sendAbortMessage is abstract and must be overridden') {
+					throw err;
+				}
 			})
 		]);
 	});

--- a/test/specs/JobWorkerMediator.spec.js
+++ b/test/specs/JobWorkerMediator.spec.js
@@ -33,6 +33,7 @@ describe('JobWorkerMediator', function() {
 		};
 		var mediator = new JobWorkerMediator(trackedJob);
 		expect(mediator.trackedJob).toBe(trackedJob, 'Expected JobWorkerMediator#trackedJob %s to be the tracked job');
+		expect(mediator.forked).toBe(false, 'Expected JobWorkerMediator#forked %s to be %s');
 		expect(mediator.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 		expect(mediator.settled).toBe(false, 'Expected JobWorkerMediator#settled %s to be %s');
 		expect(mediator.exited).toBe(false, 'Expected JobWorkerMediator#exited %s to be %s');
@@ -92,10 +93,12 @@ describe('JobWorkerMediator', function() {
 			JobWorkerMediator.apply(this, arguments);
 			expect.spyOn(this, 'execWorker').andCall(function() {
 				expect(this.initStartupTimeout.calls.length).toBe(1, 'Expected JobWorkerMediator#initStartupTimeout call count %s to be %s');
+				expect(this.forked).toBe(false, 'Expected JobWorkerMediator#forked %s to be %s');
 				expect(this.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 			});
 			expect.spyOn(this, 'initStartupTimeout').andCall(function() {
 				expect(this.execWorker.calls.length).toBe(0, 'Expected JobWorkerMediator#execWorker call count %s to be %s');
+				expect(this.forked).toBe(false, 'Expected JobWorkerMediator#forked %s to be %s');
 				expect(this.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 			});
 		});
@@ -105,7 +108,8 @@ describe('JobWorkerMediator', function() {
 			.then(function() {
 				expect(mediator.execWorker.calls.length).toBe(1, 'Expected JobWorkerMediator#execWorker call count %s to be %s');
 				expect(mediator.initStartupTimeout.calls.length).toBe(1, 'Expected JobWorkerMediator#initStartupTimeout call count %s to be %s');
-				expect(mediator.started).toBe(true, 'Expected JobWorkerMediator#started %s to be %s');
+				expect(mediator.forked).toBe(true, 'Expected JobWorkerMediator#forked %s to be %s');
+				expect(mediator.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 			});
 	});
 
@@ -236,7 +240,9 @@ describe('JobWorkerMediator', function() {
 			});
 
 			mediator.startWorker().then(function() {
+				expect(mediator.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 				mediator.handleStartupConfirmation();
+				expect(mediator.started).toBe(true, 'Expected JobWorkerMediator#started %s to be %s');
 
 				expect(mediator.settled).toBe(false, 'Expected JobWorkerMediator#settled %s to be %s');
 				expect(mediator.stopMediation.calls.length).toBe(0, 'Expected JobWorkerMediator#stopMediation call count %s to be %s');
@@ -498,7 +504,7 @@ describe('JobWorkerMediator', function() {
 		});
 	});
 
-	it('should clear timeout startup once JobWorkerMediator#handleStartupConfirmation is called', function() {
+	it('should clear startup timeout and set JobWorkerMediator#started once JobWorkerMediator#handleStartupConfirmation is called', function() {
 		var expectedResult = {};
 
 		var trackedJob = {
@@ -528,7 +534,9 @@ describe('JobWorkerMediator', function() {
 				.on(constants.EVENT_JOB_FAILURE, reject);
 			mediator.startWorker().then(function() {
 				setTimeout(function() {
+					expect(mediator.started).toBe(false, 'Expected JobWorkerMediator#started %s to be %s');
 					mediator.handleStartupConfirmation();
+					expect(mediator.started).toBe(true, 'Expected JobWorkerMediator#started %s to be %s');
 				}, 1);
 
 				setTimeout(function() {

--- a/test/specs/errors.spec.js
+++ b/test/specs/errors.spec.js
@@ -10,6 +10,7 @@ describe('errors', function() {
 		//'InvalidWorkerPayloadError',
 		'InvalidUniqueKeyError',
 		'JobForkError',
+		'JobAbortedError',
 		'InvalidJobParamError',
 		'UnsupportedMiddlewareTypeError',
 		'JobWorkerHandlerError'
@@ -115,6 +116,16 @@ describe('errors', function() {
 		expect(err.hasOwnProperty('error')).toBe(false);
 		expect(err.hasOwnProperty('code')).toBe(false);
 		expect(err.signal).toBe('FOO');
+	});
+
+	it('should instantiate "JobAbortedError"', function() {
+		var err = new errors.JobAbortedError('foo', 'bar', 'msg');
+		expect(err).toBeA(Error);
+		expect(err.name).toBe('JobAbortedError');
+		expect(err.message).toBe('Job aborted: msg');
+		expect(err.jobName).toBe('foo');
+		expect(err.jobId).toBe('bar');
+		expect(err.abortReason).toBe('msg');
 	});
 
 	it('should instantiate "InvalidJobParamError"', function() {


### PR DESCRIPTION
Breaking changes:

* Add abstract JobWorkerMediator#sendAbortMessage method.
* Change [JobWorkerMediator#started](https://github.com/amekkawi/jobhub/blob/a4fdf9248791f40860474d9e5e5b0dc74fbb8fa5/docs/api-protected/JobWorkerMediator.md#JobWorkerMediator+started) to set to true once the startup confirmation is received.
* Add JobWorkerMediator#forked which is set to true on child process fork, replacing the previous behavior of JobWorkerMediator#started.

Non-breaking API changes:

* Add TrackedJob#aborted
* Add TrackedJob#abortReason
* Add TrackedJob#abort
* Add HubManager#event:jobAbort
* Add TrackedJob#event:jobAbort
* Add 6th argument to 'workerBuildJobArg' middleware to add abort listener

Resolves #1