### PR TITLE
Add support for controlling concurrently running jobs

### DIFF
--- a/docs/api-protected/HubManager.md
+++ b/docs/api-protected/HubManager.md
@@ -13,6 +13,7 @@ Manages the lifecycle of jobs.
     * [.options](HubManager.md#HubManager+options) : <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>
     * [.middleware](HubManager.md#HubManager+middleware) : <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
     * [.jobs](HubManager.md#HubManager+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
+    * [.jobExecutor](HubManager.md#HubManager+jobExecutor) : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
     * [.start()](HubManager.md#HubManager+start) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.addSyncMiddlware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddlware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.getSupportedSyncMiddleware()](HubManager.md#HubManager+getSupportedSyncMiddleware) ⇒ <code>Array.&lt;string&gt;</code>
@@ -58,6 +59,12 @@ Middleware store used by the HubManager.
 
 ### hubManager.jobs : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
 Stores [JobConfig](JobConfig.md#JobConfig) registered for the HubManager.
+
+**Kind**: instance property of <code>[HubManager](HubManager.md#HubManager)</code>  
+<a name="HubManager+jobExecutor"></a>
+
+### hubManager.jobExecutor : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Manages running queued jobs.
 
 **Kind**: instance property of <code>[HubManager](HubManager.md#HubManager)</code>  
 <a name="HubManager+start"></a>

--- a/docs/api-protected/HubManagerOptions.md
+++ b/docs/api-protected/HubManagerOptions.md
@@ -11,6 +11,8 @@ Configuration options for the [HubManager](HubManager.md#HubManager).
     * [.jobsModulePath](HubManagerOptions.md#HubManagerOptions+jobsModulePath) : <code>string</code>
     * [.initModulePath](HubManagerOptions.md#HubManagerOptions+initModulePath) : <code>null</code> &#124; <code>string</code>
     * [.forkModulePath](HubManagerOptions.md#HubManagerOptions+forkModulePath) : <code>string</code>
+    * [.jobExecutorClass](HubManagerOptions.md#HubManagerOptions+jobExecutorClass) : <code>function</code> &#124; <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+    * [.jobExecutorOptions](HubManagerOptions.md#HubManagerOptions+jobExecutorOptions) : <code>object</code> &#124; <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
     * [.terminationSIGTERMTimeout](HubManagerOptions.md#HubManagerOptions+terminationSIGTERMTimeout) : <code>number</code>
     * [.terminationSIGKILLTimeout](HubManagerOptions.md#HubManagerOptions+terminationSIGKILLTimeout) : <code>number</code>
     * [.workerStartupTimeout](HubManagerOptions.md#HubManagerOptions+workerStartupTimeout) : <code>number</code>
@@ -36,6 +38,20 @@ Path to node script used to fork the child processes.
 
 **Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
 **Default**: <code>&quot;jobhub/lib/worker.js&quot;</code>  
+<a name="HubManagerOptions+jobExecutorClass"></a>
+
+### hubManagerOptions.jobExecutorClass : <code>function</code> &#124; <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Overrides class used for [HubManager#jobExecutor](HubManager.md#HubManager+jobExecutor).
+
+**Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
+**Default**: <code>require(&#x27;jobhub/lib/JobExecutorBuiltin&#x27;)</code>  
+<a name="HubManagerOptions+jobExecutorOptions"></a>
+
+### hubManagerOptions.jobExecutorOptions : <code>object</code> &#124; <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Option overrides passed to the [JobExecutor](JobExecutor.md#JobExecutor).
+
+**Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
+**Default**: <code>{}</code>  
 <a name="HubManagerOptions+terminationSIGTERMTimeout"></a>
 
 ### hubManagerOptions.terminationSIGTERMTimeout : <code>number</code>

--- a/docs/api-protected/JobExecutor.md
+++ b/docs/api-protected/JobExecutor.md
@@ -1,0 +1,52 @@
+# [jobhub Extended API](README.md): Class:
+
+<a name="JobExecutor"></a>
+
+## *JobExecutor*
+Manages running jobs that have been queued using [HubManager#queueJob](HubManager.md#HubManager+queueJob).
+
+**Kind**: global abstract class  
+
+* *[JobExecutor](JobExecutor.md#JobExecutor)*
+    * *[new JobExecutor(options, manager)](JobExecutor.md#JobExecutor)*
+    * *[.options](JobExecutor.md#JobExecutor+options) : <code>object</code>*
+    * *[.manager](JobExecutor.md#JobExecutor+manager) : <code>[HubManager](HubManager.md#HubManager)</code>*
+    * **[.add(trackedJob)](JobExecutor.md#JobExecutor+add)**
+    * **[.getStatus()](JobExecutor.md#JobExecutor+getStatus) ⇒ <code>object</code>**
+
+<a name="new_JobExecutor_new"></a>
+
+### *new JobExecutor(options, manager)*
+
+| Param | Type |
+| --- | --- |
+| options | <code>object</code> | 
+| manager | <code>[HubManager](HubManager.md#HubManager)</code> | 
+
+<a name="JobExecutor+options"></a>
+
+### *jobExecutor.options : <code>object</code>*
+**Kind**: instance property of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+**Access:** protected  
+<a name="JobExecutor+manager"></a>
+
+### *jobExecutor.manager : <code>[HubManager](HubManager.md#HubManager)</code>*
+**Kind**: instance property of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+**Access:** protected  
+<a name="JobExecutor+add"></a>
+
+### **jobExecutor.add(trackedJob)**
+Add a tracked job to be run.
+
+**Kind**: instance abstract method of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
+
+<a name="JobExecutor+getStatus"></a>
+
+### **jobExecutor.getStatus() ⇒ <code>object</code>**
+Get detail about queued and running jobs.
+
+**Kind**: instance abstract method of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  

--- a/docs/api-protected/JobExecutorBuiltin.md
+++ b/docs/api-protected/JobExecutorBuiltin.md
@@ -1,0 +1,82 @@
+# [jobhub Extended API](README.md): Class:
+
+<a name="JobExecutorBuiltin"></a>
+
+## JobExecutorBuiltin ⇐ <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Manages running jobs that have been queued using [HubManager#queueJob](HubManager.md#HubManager+queueJob).
+
+**Kind**: global class  
+**Extends:** <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+
+* [JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin) ⇐ <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+    * [new JobExecutorBuiltin(options, manager)](JobExecutorBuiltin.md#JobExecutorBuiltin)
+    * _instance_
+        * [.options](JobExecutorBuiltin.md#JobExecutor+options) : <code>object</code>
+        * [.manager](JobExecutorBuiltin.md#JobExecutor+manager) : <code>[HubManager](HubManager.md#HubManager)</code>
+        * [.add(trackedJob)](JobExecutorBuiltin.md#JobExecutorBuiltin+add)
+        * [.getStatus()](JobExecutorBuiltin.md#JobExecutorBuiltin+getStatus) ⇒ <code>Object</code>
+    * _static_
+        * [.parseOptions(options, defaultOptions)](JobExecutorBuiltin.md#JobExecutorBuiltin.parseOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+        * [.getDefaultOptions()](JobExecutorBuiltin.md#JobExecutorBuiltin.getDefaultOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+
+<a name="new_JobExecutorBuiltin_new"></a>
+
+### new JobExecutorBuiltin(options, manager)
+
+| Param | Type |
+| --- | --- |
+| options | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+| manager | <code>[HubManager](HubManager.md#HubManager)</code> | 
+
+<a name="JobExecutor+options"></a>
+
+### jobExecutorBuiltin.options : <code>object</code>
+**Kind**: instance property of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Access:** protected  
+<a name="JobExecutor+manager"></a>
+
+### jobExecutorBuiltin.manager : <code>[HubManager](HubManager.md#HubManager)</code>
+**Kind**: instance property of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Access:** protected  
+<a name="JobExecutorBuiltin+add"></a>
+
+### jobExecutorBuiltin.add(trackedJob)
+Add a tracked job to be run.
+
+**Kind**: instance method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Overrides:** <code>[add](JobExecutor.md#JobExecutor+add)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
+
+<a name="JobExecutorBuiltin+getStatus"></a>
+
+### jobExecutorBuiltin.getStatus() ⇒ <code>Object</code>
+Get detail about queued and running jobs.
+
+Returns:
+* `maxConcurrent` - Maximum concurrent jobs that can run.
+* `runningCount` - Number of running jobs.
+* `queuedCount` - Number of jobs waiting to run.
+
+**Kind**: instance method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Overrides:** <code>[getStatus](JobExecutor.md#JobExecutor+getStatus)</code>  
+<a name="JobExecutorBuiltin.parseOptions"></a>
+
+### JobExecutorBuiltin.parseOptions(options, defaultOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Parse the JobExecutorBuiltin's options. Called by [HubManager](HubManager.md#HubManager).
+
+**Kind**: static method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+
+| Param | Type |
+| --- | --- |
+| options | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+| defaultOptions | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+
+<a name="JobExecutorBuiltin.getDefaultOptions"></a>
+
+### JobExecutorBuiltin.getDefaultOptions() ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Get the default options for the JobExecutorBuiltin. Called by [HubManager](HubManager.md#HubManager).
+
+**Kind**: static method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  

--- a/docs/api-protected/JobExecutorBuiltinOptions.md
+++ b/docs/api-protected/JobExecutorBuiltinOptions.md
@@ -1,0 +1,15 @@
+# [jobhub Extended API](README.md): Typedef:
+
+<a name="JobExecutorBuiltinOptions"></a>
+
+## JobExecutorBuiltinOptions : <code>object</code>
+Configuration options for [JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin).
+
+**Kind**: global typedef  
+<a name="JobExecutorBuiltinOptions+maxConcurrent"></a>
+
+### jobExecutorBuiltinOptions.maxConcurrent : <code>number</code>
+Maximum number of jobs that will be run concurrently. Set to 0 to allow unlimited concurrently running jobs.
+
+**Kind**: instance property of <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>  
+**Default**: <code>0</code>  

--- a/docs/api-protected/README.md
+++ b/docs/api-protected/README.md
@@ -18,6 +18,9 @@
 <dd><p>Passed to <a href="JobConfig.md#JobConfig+run">JobConfig#run</a> and <a href="JobConfig.md#JobConfig+quickRun">JobConfig#quickRun</a>
 to provide information about the job and facilitate communicate progress/success/failure.</p>
 </dd>
+<dt><a href="JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions">JobExecutorBuiltinOptions</a> : <code>object</code></dt>
+<dd><p>Configuration options for <a href="JobExecutorBuiltin.md#JobExecutorBuiltin">JobExecutorBuiltin</a>.</p>
+</dd>
 </dl>
 
 ## Classes
@@ -28,6 +31,12 @@ to provide information about the job and facilitate communicate progress/success
 </dd>
 <dt><a href="JobConfigStore.md#JobConfigStore">JobConfigStore</a></dt>
 <dd><p>Manages registered job config.</p>
+</dd>
+<dt><a href="JobExecutor.md#JobExecutor">JobExecutor</a></dt>
+<dd><p>Manages running jobs that have been queued using <a href="HubManager.md#HubManager+queueJob">HubManager#queueJob</a>.</p>
+</dd>
+<dt><a href="JobExecutorBuiltin.md#JobExecutorBuiltin">JobExecutorBuiltin</a> ⇐ <code><a href="JobExecutor.md#JobExecutor">JobExecutor</a></code></dt>
+<dd><p>Manages running jobs that have been queued using <a href="HubManager.md#HubManager+queueJob">HubManager#queueJob</a>.</p>
 </dd>
 <dt><a href="JobWorker.md#JobWorker">JobWorker</a> ⇐ <code>EventEmitter</code></dt>
 <dd><p>Responsible for running the job in the forked worker process.</p>

--- a/docs/api-protected/module_jobhub_lib_util.md
+++ b/docs/api-protected/module_jobhub_lib_util.md
@@ -22,6 +22,7 @@ var util = require("jobhub/lib/util");
     * [.dehydrateError(err)](module_jobhub_lib_util.md#module_jobhub/lib/util.dehydrateError) ⇒ <code>object</code>
     * [.promiseTry(fn)](module_jobhub_lib_util.md#module_jobhub/lib/util.promiseTry) ⇒ <code>Promise</code>
     * [.objectValues(obj)](module_jobhub_lib_util.md#module_jobhub/lib/util.objectValues) ⇒ <code>Array</code>
+    * [.extendDefaultOptions(options, defaultOptions)](module_jobhub_lib_util.md#module_jobhub/lib/util.extendDefaultOptions) ⇒ <code>object</code>
 
 <a name="module_jobhub/lib/util.getDefaultManagerOptions"></a>
 
@@ -152,4 +153,17 @@ Polyfill for Object.values.
 | Param | Type |
 | --- | --- |
 | obj | <code>object</code> | 
+
+<a name="module_jobhub/lib/util.extendDefaultOptions"></a>
+
+### jobhub/lib/util.extendDefaultOptions(options, defaultOptions) ⇒ <code>object</code>
+Create an options object that only includes the props from a "default" options object.
+
+**Kind**: static method of <code>[jobhub/lib/util](module_jobhub_lib_util.md#module_jobhub/lib/util)</code>  
+**Access:** protected  
+
+| Param | Type |
+| --- | --- |
+| options | <code>object</code> | 
+| defaultOptions | <code>object</code> | 
 

--- a/docs/api/HubManager.md
+++ b/docs/api/HubManager.md
@@ -13,6 +13,7 @@ Manages the lifecycle of jobs.
     * [.options](HubManager.md#HubManager+options) : <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>
     * [.middleware](HubManager.md#HubManager+middleware) : <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
     * [.jobs](HubManager.md#HubManager+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
+    * [.jobExecutor](HubManager.md#HubManager+jobExecutor) : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
     * [.start()](HubManager.md#HubManager+start) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.addSyncMiddlware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddlware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.getUniqueKey(job, [params])](HubManager.md#HubManager+getUniqueKey) ⇒ <code>string</code> &#124; <code>null</code>
@@ -55,6 +56,12 @@ Middleware store used by the HubManager.
 
 ### hubManager.jobs : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
 Stores [JobConfig](JobConfig.md#JobConfig) registered for the HubManager.
+
+**Kind**: instance property of <code>[HubManager](HubManager.md#HubManager)</code>  
+<a name="HubManager+jobExecutor"></a>
+
+### hubManager.jobExecutor : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Manages running queued jobs.
 
 **Kind**: instance property of <code>[HubManager](HubManager.md#HubManager)</code>  
 <a name="HubManager+start"></a>

--- a/docs/api/HubManagerOptions.md
+++ b/docs/api/HubManagerOptions.md
@@ -11,6 +11,8 @@ Configuration options for the [HubManager](HubManager.md#HubManager).
     * [.jobsModulePath](HubManagerOptions.md#HubManagerOptions+jobsModulePath) : <code>string</code>
     * [.initModulePath](HubManagerOptions.md#HubManagerOptions+initModulePath) : <code>null</code> &#124; <code>string</code>
     * [.forkModulePath](HubManagerOptions.md#HubManagerOptions+forkModulePath) : <code>string</code>
+    * [.jobExecutorClass](HubManagerOptions.md#HubManagerOptions+jobExecutorClass) : <code>function</code> &#124; <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+    * [.jobExecutorOptions](HubManagerOptions.md#HubManagerOptions+jobExecutorOptions) : <code>object</code> &#124; <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
     * [.terminationSIGTERMTimeout](HubManagerOptions.md#HubManagerOptions+terminationSIGTERMTimeout) : <code>number</code>
     * [.terminationSIGKILLTimeout](HubManagerOptions.md#HubManagerOptions+terminationSIGKILLTimeout) : <code>number</code>
     * [.workerStartupTimeout](HubManagerOptions.md#HubManagerOptions+workerStartupTimeout) : <code>number</code>
@@ -36,6 +38,20 @@ Path to node script used to fork the child processes.
 
 **Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
 **Default**: <code>&quot;jobhub/lib/worker.js&quot;</code>  
+<a name="HubManagerOptions+jobExecutorClass"></a>
+
+### hubManagerOptions.jobExecutorClass : <code>function</code> &#124; <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Overrides class used for [HubManager#jobExecutor](HubManager.md#HubManager+jobExecutor).
+
+**Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
+**Default**: <code>require(&#x27;jobhub/lib/JobExecutorBuiltin&#x27;)</code>  
+<a name="HubManagerOptions+jobExecutorOptions"></a>
+
+### hubManagerOptions.jobExecutorOptions : <code>object</code> &#124; <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Option overrides passed to the [JobExecutor](JobExecutor.md#JobExecutor).
+
+**Kind**: instance property of <code>[HubManagerOptions](HubManagerOptions.md#HubManagerOptions)</code>  
+**Default**: <code>{}</code>  
 <a name="HubManagerOptions+terminationSIGTERMTimeout"></a>
 
 ### hubManagerOptions.terminationSIGTERMTimeout : <code>number</code>

--- a/docs/api/JobExecutor.md
+++ b/docs/api/JobExecutor.md
@@ -1,0 +1,40 @@
+# [jobhub API](README.md): Class:
+
+<a name="JobExecutor"></a>
+
+## *JobExecutor*
+Manages running jobs that have been queued using [HubManager#queueJob](HubManager.md#HubManager+queueJob).
+
+**Kind**: global abstract class  
+
+* *[JobExecutor](JobExecutor.md#JobExecutor)*
+    * *[new JobExecutor(options, manager)](JobExecutor.md#JobExecutor)*
+    * **[.add(trackedJob)](JobExecutor.md#JobExecutor+add)**
+    * **[.getStatus()](JobExecutor.md#JobExecutor+getStatus) ⇒ <code>object</code>**
+
+<a name="new_JobExecutor_new"></a>
+
+### *new JobExecutor(options, manager)*
+
+| Param | Type |
+| --- | --- |
+| options | <code>object</code> | 
+| manager | <code>[HubManager](HubManager.md#HubManager)</code> | 
+
+<a name="JobExecutor+add"></a>
+
+### **jobExecutor.add(trackedJob)**
+Add a tracked job to be run.
+
+**Kind**: instance abstract method of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
+
+<a name="JobExecutor+getStatus"></a>
+
+### **jobExecutor.getStatus() ⇒ <code>object</code>**
+Get detail about queued and running jobs.
+
+**Kind**: instance abstract method of <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  

--- a/docs/api/JobExecutorBuiltin.md
+++ b/docs/api/JobExecutorBuiltin.md
@@ -1,0 +1,70 @@
+# [jobhub API](README.md): Class:
+
+<a name="JobExecutorBuiltin"></a>
+
+## JobExecutorBuiltin ⇐ <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+Manages running jobs that have been queued using [HubManager#queueJob](HubManager.md#HubManager+queueJob).
+
+**Kind**: global class  
+**Extends:** <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>  
+
+* [JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin) ⇐ <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
+    * [new JobExecutorBuiltin(options, manager)](JobExecutorBuiltin.md#JobExecutorBuiltin)
+    * _instance_
+        * [.add(trackedJob)](JobExecutorBuiltin.md#JobExecutorBuiltin+add)
+        * [.getStatus()](JobExecutorBuiltin.md#JobExecutorBuiltin+getStatus) ⇒ <code>Object</code>
+    * _static_
+        * [.parseOptions(options, defaultOptions)](JobExecutorBuiltin.md#JobExecutorBuiltin.parseOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+        * [.getDefaultOptions()](JobExecutorBuiltin.md#JobExecutorBuiltin.getDefaultOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+
+<a name="new_JobExecutorBuiltin_new"></a>
+
+### new JobExecutorBuiltin(options, manager)
+
+| Param | Type |
+| --- | --- |
+| options | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+| manager | <code>[HubManager](HubManager.md#HubManager)</code> | 
+
+<a name="JobExecutorBuiltin+add"></a>
+
+### jobExecutorBuiltin.add(trackedJob)
+Add a tracked job to be run.
+
+**Kind**: instance method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Overrides:** <code>[add](JobExecutor.md#JobExecutor+add)</code>  
+
+| Param | Type |
+| --- | --- |
+| trackedJob | <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> | 
+
+<a name="JobExecutorBuiltin+getStatus"></a>
+
+### jobExecutorBuiltin.getStatus() ⇒ <code>Object</code>
+Get detail about queued and running jobs.
+
+Returns:
+* `maxConcurrent` - Maximum concurrent jobs that can run.
+* `runningCount` - Number of running jobs.
+* `queuedCount` - Number of jobs waiting to run.
+
+**Kind**: instance method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+**Overrides:** <code>[getStatus](JobExecutor.md#JobExecutor+getStatus)</code>  
+<a name="JobExecutorBuiltin.parseOptions"></a>
+
+### JobExecutorBuiltin.parseOptions(options, defaultOptions) ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Parse the JobExecutorBuiltin's options. Called by [HubManager](HubManager.md#HubManager).
+
+**Kind**: static method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  
+
+| Param | Type |
+| --- | --- |
+| options | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+| defaultOptions | <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code> | 
+
+<a name="JobExecutorBuiltin.getDefaultOptions"></a>
+
+### JobExecutorBuiltin.getDefaultOptions() ⇒ <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>
+Get the default options for the JobExecutorBuiltin. Called by [HubManager](HubManager.md#HubManager).
+
+**Kind**: static method of <code>[JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin)</code>  

--- a/docs/api/JobExecutorBuiltinOptions.md
+++ b/docs/api/JobExecutorBuiltinOptions.md
@@ -1,0 +1,15 @@
+# [jobhub API](README.md): Typedef:
+
+<a name="JobExecutorBuiltinOptions"></a>
+
+## JobExecutorBuiltinOptions : <code>object</code>
+Configuration options for [JobExecutorBuiltin](JobExecutorBuiltin.md#JobExecutorBuiltin).
+
+**Kind**: global typedef  
+<a name="JobExecutorBuiltinOptions+maxConcurrent"></a>
+
+### jobExecutorBuiltinOptions.maxConcurrent : <code>number</code>
+Maximum number of jobs that will be run concurrently. Set to 0 to allow unlimited concurrently running jobs.
+
+**Kind**: instance property of <code>[JobExecutorBuiltinOptions](JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions)</code>  
+**Default**: <code>0</code>  

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,6 +18,9 @@
 <dd><p>Passed to <a href="JobConfig.md#JobConfig+run">JobConfig#run</a> and <a href="JobConfig.md#JobConfig+quickRun">JobConfig#quickRun</a>
 to provide information about the job and facilitate communicate progress/success/failure.</p>
 </dd>
+<dt><a href="JobExecutorBuiltinOptions.md#JobExecutorBuiltinOptions">JobExecutorBuiltinOptions</a> : <code>object</code></dt>
+<dd><p>Configuration options for <a href="JobExecutorBuiltin.md#JobExecutorBuiltin">JobExecutorBuiltin</a>.</p>
+</dd>
 </dl>
 
 ## Classes
@@ -28,6 +31,12 @@ to provide information about the job and facilitate communicate progress/success
 </dd>
 <dt><a href="JobConfigStore.md#JobConfigStore">JobConfigStore</a></dt>
 <dd><p>Manages registered job config.</p>
+</dd>
+<dt><a href="JobExecutor.md#JobExecutor">JobExecutor</a></dt>
+<dd><p>Manages running jobs that have been queued using <a href="HubManager.md#HubManager+queueJob">HubManager#queueJob</a>.</p>
+</dd>
+<dt><a href="JobExecutorBuiltin.md#JobExecutorBuiltin">JobExecutorBuiltin</a> ⇐ <code><a href="JobExecutor.md#JobExecutor">JobExecutor</a></code></dt>
+<dd><p>Manages running jobs that have been queued using <a href="HubManager.md#HubManager+queueJob">HubManager#queueJob</a>.</p>
 </dd>
 <dt><a href="JobWorker.md#JobWorker">JobWorker</a> ⇐ <code>EventEmitter</code></dt>
 <dd><p>Responsible for running the job in the forked worker process.</p>

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,3 +11,5 @@ For example: `node examples/simple`
 * `simple` - A simple usage of jobhub
 * `unique` - Demonstrates the "unique" and "uniqueKey" job config props
 * `cached-result` - Caches the result of a potentially heavy weight job so future jobs will run using quickRun instead
+* `abort-jobs` - Aborts jobs at various stages of a job, and allows the worker process to hand
+* `throttled` - Queues 10 jobs but throttles the jobs to only run 2 concurrently.

--- a/examples/throttled/index.js
+++ b/examples/throttled/index.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+
+var path = require('path');
+var jobhub = require('../../lib/index');
+
+var verbose = process.argv.indexOf('-v') >= 0;
+
+var hub = new jobhub.HubManager({
+	jobsModulePath: path.resolve(__dirname, 'jobs.js'),
+	jobExecutorOptions: {
+		maxConcurrent: 2
+	}
+}).start();
+
+if (verbose) {
+	require('../util').logManagerEvents(hub);
+}
+
+function startSlowJob(i) {
+	hub.queueJob('slowJob')
+		.on('jobStarted', function() {
+			console.log('[MANAGER] Job ' + i + ' started...')
+		})
+		.then(function() {
+			console.log('[MANAGER] Job ' + i + ' success!')
+		});
+}
+
+// Start 10 jobs, but only 2 should run at a time.
+for (var i = 1; i <= 10; i++) {
+	startSlowJob(i);
+}

--- a/examples/throttled/jobs.js
+++ b/examples/throttled/jobs.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-console,valid-jsdoc */
+
+exports.slowJob = {
+	run: function(job) {
+		setTimeout(function() {
+			job.resolve();
+		}, 2000);
+	}
+};

--- a/lib/HubManager.js
+++ b/lib/HubManager.js
@@ -6,6 +6,7 @@ var errors = require('./errors');
 var TrackedJob = require('./TrackedJob');
 var JobConfigStore = require('./JobConfigStore');
 var MiddlewareStore = require('./MiddlewareStore');
+var JobExecutorBuiltin = require('./JobExecutorBuiltin');
 
 module.exports = HubManager;
 
@@ -29,6 +30,18 @@ module.exports = HubManager;
  * Path to node script used to fork the child processes.
  * @member {string} HubManagerOptions#forkModulePath
  * @default jobhub/lib/worker.js
+ */
+
+/**
+ * Overrides class used for {@link HubManager#jobExecutor}.
+ * @member {function|JobExecutor} HubManagerOptions#jobExecutorClass
+ * @default require('jobhub/lib/JobExecutorBuiltin')
+ */
+
+/**
+ * Option overrides passed to the {@link JobExecutor}.
+ * @member {object|JobExecutorBuiltinOptions} HubManagerOptions#jobExecutorOptions
+ * @default {}
  */
 
 /**
@@ -116,6 +129,21 @@ function HubManager(options) {
 	 * @member {JobConfigStore} HubManager#jobs
 	 */
 	this.jobs = new JobConfigStore();
+
+	// Determine the JobExecutor class constructor.
+	var JobExecutorClass = options.jobExecutorClass || JobExecutorBuiltin;
+
+	// Parse the JobExecutor options.
+	var jobExecutorOptions = JobExecutorClass.parseOptions(
+		this.options.jobExecutorOptions,
+		JobExecutorClass.getDefaultOptions()
+	);
+
+	/**
+	 * Manages running queued jobs.
+	 * @member {JobExecutor} HubManager#jobExecutor
+	 */
+	this.jobExecutor = new JobExecutorClass(jobExecutorOptions, this);
 
 	// Handle cleanup once a job settles (i.e. resolves or fails)
 	var handleSettled = this.handleSettledJob.bind(this);
@@ -321,8 +349,8 @@ HubManager.prototype.queueJob = function(job, params) {
 
 	this._emitJobCreated(trackedJob);
 
-	// Start the job
-	trackedJob.run();
+	// Add the job to the executor, which will decide when TrackedJob#run is called.
+	this.jobExecutor.add(trackedJob);
 
 	return trackedJob;
 };

--- a/lib/JobExecutor.js
+++ b/lib/JobExecutor.js
@@ -1,0 +1,43 @@
+module.exports = JobExecutor;
+
+/**
+ * @classdesc Manages running jobs that have been queued using {@link HubManager#queueJob}.
+ *
+ * @class
+ * @abstract
+ * @param {object} options
+ * @param {HubManager} manager
+ */
+function JobExecutor(options, manager) {
+	/**
+	 * @protected
+	 * @member {object} JobExecutor#options
+	 */
+	this.options = options;
+
+	/**
+	 * @protected
+	 * @member {HubManager} JobExecutor#manager
+	 */
+	this.manager = manager;
+}
+
+/**
+ * Add a tracked job to be run.
+ *
+ * @abstract
+ * @param {TrackedJob} trackedJob
+ */
+JobExecutor.prototype.add = function(trackedJob) { // eslint-disable-line no-unused-vars
+	throw new Error('JobExecutor#add is abstract and must be overridden');
+};
+
+/**
+ * Get detail about queued and running jobs.
+ *
+ * @abstract
+ * @returns {object}
+ */
+JobExecutor.prototype.getStatus = function() {
+	throw new Error('JobExecutor#getStatus is abstract and must be overridden');
+};

--- a/lib/JobExecutorBuiltin.js
+++ b/lib/JobExecutorBuiltin.js
@@ -1,0 +1,166 @@
+var inherits = require('util').inherits;
+var util = require('./util');
+var errors = require('./errors');
+var constants = require('./constants');
+var JobExecutor = require('./JobExecutor');
+
+module.exports = JobExecutorBuiltin;
+
+/**
+ * Configuration options for {@link JobExecutorBuiltin}.
+ * @typedef {object} JobExecutorBuiltinOptions
+ */
+
+/**
+ * Maximum number of jobs that will be run concurrently. Set to 0 to allow unlimited concurrently running jobs.
+ * @member {number} JobExecutorBuiltinOptions#maxConcurrent
+ * @default 0
+ */
+
+/**
+ * @classdesc Manages running jobs that have been queued using {@link HubManager#queueJob}.
+ *
+ * @class
+ * @augments JobExecutor
+ * @param {JobExecutorBuiltinOptions} options
+ * @param {HubManager} manager
+ */
+function JobExecutorBuiltin(options, manager) {
+	JobExecutor.call(this, options, manager);
+
+	/**
+	 * Number of running jobs.
+	 *
+	 * @private
+	 * @member {number} JobExecutorBuiltin#_runningCount
+	 */
+	this._runningCount = 0;
+
+	/**
+	 * Jobs waiting to run.
+	 *
+	 * @private
+	 * @member {TrackedJob[]} JobExecutorBuiltin#_queue
+	 */
+	this._queue = [];
+
+	/**
+	 * Indicates if a (throttled) capacity check has already been queued.
+	 *
+	 * @private
+	 * @member {boolean} JobExecutorBuiltin#_checkingForCapacity
+	 */
+	this._checkingForCapacity = false;
+}
+
+inherits(JobExecutorBuiltin, JobExecutor);
+
+/**
+ * Add a tracked job to be run.
+ *
+ * @param {TrackedJob} trackedJob
+ */
+JobExecutorBuiltin.prototype.add = function(trackedJob) {
+	this._queue.push(trackedJob);
+	this._checkForCapacity();
+};
+
+/**
+ * Get detail about queued and running jobs.
+ *
+ * Returns:
+ * * `maxConcurrent` - Maximum concurrent jobs that can run.
+ * * `runningCount` - Number of running jobs.
+ * * `queuedCount` - Number of jobs waiting to run.
+ *
+ * @returns {{ maxConcurrent: number, runningCount: number, queuedCount: number }}
+ */
+JobExecutorBuiltin.prototype.getStatus = function() {
+	return {
+		maxConcurrent: this.options.maxConcurrent,
+		queuedCount: this._queue.length,
+		runningCount: this._runningCount
+	};
+};
+
+/**
+ * Check for capacity to run more jobs. This check is throttled using `setImmediate`.
+ *
+ * @private
+ */
+JobExecutorBuiltin.prototype._checkForCapacity = function() {
+	if (!this._checkingForCapacity) {
+		this._checkingForCapacity = true;
+
+		// Use setImmediate to throttle synchronously adding multiple jobs
+		setImmediate(function() {
+			this._checkingForCapacity = false;
+			this._runToCapacity();
+		}.bind(this));
+	}
+};
+
+/**
+ * Run jobs until the capacity is reached.
+ *
+ * @private
+ */
+JobExecutorBuiltin.prototype._runToCapacity = function() {
+	var maxCurrent = this.options.maxConcurrent;
+	while (this._queue.length && (maxCurrent <= 0 || this._runningCount < maxCurrent)) {
+		var trackedJob = this._queue.shift();
+
+		// Only run if it has no promise, meaning that run has not already been called.
+		if (!trackedJob.promise) {
+			this._runningCount++;
+
+			var onSettle = function cb(trackedJob) {
+				trackedJob.removeListener(constants.EVENT_JOB_SUCCESS, cb);
+				trackedJob.removeListener(constants.EVENT_JOB_FAILURE, cb);
+
+				this._runningCount--;
+				this._checkForCapacity();
+			}.bind(this, trackedJob);
+
+			trackedJob.on(constants.EVENT_JOB_SUCCESS, onSettle);
+			trackedJob.on(constants.EVENT_JOB_FAILURE, onSettle);
+
+			trackedJob.run();
+		}
+	}
+};
+
+/**
+ * Parse the JobExecutorBuiltin's options. Called by {@link HubManager}.
+ *
+ * @static
+ * @param {JobExecutorBuiltinOptions} options
+ * @param {JobExecutorBuiltinOptions} defaultOptions
+ * @returns {JobExecutorBuiltinOptions}
+ */
+JobExecutorBuiltin.parseOptions = function(options, defaultOptions) {
+	options = util.extendDefaultOptions(options, defaultOptions);
+
+	if (typeof options.maxConcurrent !== 'number' || !isFinite(options.maxConcurrent)) {
+		throw new errors.InvalidManagerOptionsError(
+			'HubManager "jobExecutorOptions.maxConcurrent" option must be a number',
+			'jobExecutorOptions.maxConcurrent'
+		);
+	}
+
+	options.maxConcurrent = Math.max(0, options.maxConcurrent);
+
+	return options;
+};
+
+/**
+ * Get the default options for the JobExecutorBuiltin. Called by {@link HubManager}.
+ *
+ * @static
+ * @returns {JobExecutorBuiltinOptions}
+ */
+JobExecutorBuiltin.getDefaultOptions = function() {
+	return {
+		maxConcurrent: 0
+	};
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -44,15 +44,7 @@ exports.getDefaultManagerOptions = function() {
  * @returns {HubManagerOptions}
  */
 exports.parseManagerOptions = function(options, defaultOptions) {
-	options = Object.keys(defaultOptions).reduce(function(ret, key) {
-		if (options && hasOwnProperty.call(options, key)) {
-			ret[key] = options[key];
-		}
-		else {
-			ret[key] = defaultOptions[key];
-		}
-		return ret;
-	}, {});
+	options = exports.extendDefaultOptions(options, defaultOptions);
 
 	if (options.initModulePath && typeof options.initModulePath !== 'string') {
 		throw new errors.InvalidManagerOptionsError(
@@ -424,4 +416,25 @@ exports.objectValues = function(obj) {
 	return Object.keys(obj).map(function(key) {
 		return obj[key];
 	});
+};
+
+/**
+ * Create an options object that only includes the props from a "default" options object.
+ *
+ * @static
+ * @protected
+ * @param {object} options
+ * @param {object} defaultOptions
+ * @returns {object}
+ */
+exports.extendDefaultOptions = function(options, defaultOptions) {
+	return Object.keys(defaultOptions).reduce(function(ret, key) {
+		if (options && hasOwnProperty.call(options, key)) {
+			ret[key] = options[key];
+		}
+		else {
+			ret[key] = defaultOptions[key];
+		}
+		return ret;
+	}, {});
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,6 +27,8 @@ exports.getDefaultManagerOptions = function() {
 		forkModulePath: path.resolve(__dirname, 'worker.js'),
 		initModulePath: null,
 		jobsModulePath: null,
+		jobExecutorClass: null,
+		jobExecutorOptions: null,
 		terminationSIGTERMTimeout: 60000,
 		terminationSIGKILLTimeout: 60000,
 		workerStartupTimeout: 20000,
@@ -92,6 +94,20 @@ exports.parseManagerOptions = function(options, defaultOptions) {
 		throw new errors.InvalidManagerOptionsError(
 			'HubManager "createId" option must be a function',
 			'createId'
+		);
+	}
+
+	if (options.jobExecutorClass && typeof options.jobExecutorClass !== 'function') {
+		throw new errors.InvalidManagerOptionsError(
+			'HubManager "jobExecutorClass" option must be a function, if specified',
+			'jobExecutorClass'
+		);
+	}
+
+	if (options.jobExecutorOptions && typeof options.jobExecutorOptions !== 'object') {
+		throw new errors.InvalidManagerOptionsError(
+			'HubManager "jobExecutorOptions" option must be an object, if specified',
+			'jobExecutorOptions'
 		);
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,8 @@ require('./specs/errors.spec');
 require('./specs/util.spec');
 require('./specs/MiddlewareStore.spec');
 require('./specs/JobConfigStore.spec');
+require('./specs/JobExecutor.spec');
+require('./specs/JobExecutorBuiltin.spec');
 require('./specs/TrackedJob.spec');
 require('./specs/JobWorkerMediator.spec');
 require('./specs/JobWorkerIPCMediator.spec');

--- a/test/specs/JobExecutor.spec.js
+++ b/test/specs/JobExecutor.spec.js
@@ -1,0 +1,37 @@
+var expect = require('expect');
+var JobExecutor = require('../../lib/JobExecutor');
+
+describe('JobExecutor', function() {
+	it('should set properties from constructor', function() {
+		var options = {};
+		var manager = {};
+		var executor = new JobExecutor(options, manager);
+		expect(executor.options).toBe(options, 'Expected JobExecutor#options %s to be %s');
+		expect(executor.manager).toBe(manager, 'Expected JobExecutor#manager %s to be %s');
+	});
+
+	it('should throw error if not implemented abstract methods', function() {
+		var executor = new JobExecutor({}, {});
+
+		return Promise.all([
+			new Promise(function() {
+				executor.add({});
+				throw new Error('Expected to throw error for JobExecutor#add');
+			}).catch(function(err) {
+				if (!(err instanceof Error) || err.message !== 'JobExecutor#add is abstract and must be overridden') {
+					throw err;
+				}
+			}),
+			new Promise(function() {
+				executor.getStatus({});
+				throw new Error('Expected to throw error for JobExecutor#getStatus');
+			}).catch(function(err) {
+				if (!(err instanceof Error) || err.message !== 'JobExecutor#getStatus is abstract and must be overridden') {
+					throw err;
+				}
+			})
+		]);
+	});
+
+
+});

--- a/test/specs/JobExecutorBuiltin.spec.js
+++ b/test/specs/JobExecutorBuiltin.spec.js
@@ -1,0 +1,329 @@
+var EventEmitter = require('events').EventEmitter;
+var expect = require('expect');
+var constants = require('../../lib/constants');
+var errors = require('../../lib/errors');
+var JobExecutor = require('../../lib/JobExecutor');
+var JobExecutorBuiltin = require('../../lib/JobExecutorBuiltin');
+
+describe('JobExecutorBuiltin', function() {
+	function createTrackedJobFixture(proto) {
+		return Object.assign(new EventEmitter(), {
+			run: expect.createSpy()
+		}, proto);
+	}
+
+	it('should returns defaults from JobExecutorBuiltin.getDefaultOptions', function() {
+		expect(JobExecutorBuiltin.getDefaultOptions).toBeA(Function);
+		var options = JobExecutorBuiltin.getDefaultOptions();
+		expect(Object.keys(options)).toEqual(['maxConcurrent']);
+		expect(options.maxConcurrent).toBe(0);
+	});
+
+	it('should set properties from constructor', function() {
+		var options = JobExecutorBuiltin.getDefaultOptions();
+		var manager = {};
+		var executor = new JobExecutorBuiltin(options, manager);
+		expect(executor).toBeA(JobExecutor, 'Expected JobExecutorBuiltin#options %s to be a %s');
+		expect(executor.options).toBe(options, 'Expected JobExecutorBuiltin#options %s to be %s');
+		expect(executor.manager).toBe(manager, 'Expected JobExecutorBuiltin#manager %s to be %s');
+	});
+
+	it('should return counts via JobExecutorBuiltin#getStatus', function() {
+		var executor = new JobExecutorBuiltin({
+			maxConcurrent: 10
+		}, {});
+		var status = executor.getStatus();
+		expect(status).toBeA(Object);
+		expect(Object.keys(status)).toEqual(['maxConcurrent', 'queuedCount', 'runningCount']);
+		expect(status.maxConcurrent).toBe(10);
+		expect(status.queuedCount).toBe(0);
+		expect(status.runningCount).toBe(0);
+	});
+
+	it('should add jobs to queue and run up to capacity', function() {
+		var executor = new JobExecutorBuiltin({
+			maxConcurrent: 2
+		}, {});
+
+		var runSpy = expect.createSpy();
+
+		executor.add(createTrackedJobFixture({
+			run: runSpy
+		}));
+		executor.add(createTrackedJobFixture({
+			run: runSpy
+		}));
+		executor.add(createTrackedJobFixture({
+			run: runSpy
+		}));
+
+		var status = executor.getStatus();
+		expect(status.queuedCount).toBe(3);
+		expect(status.runningCount).toBe(0);
+		expect(runSpy.calls.length).toBe(0);
+
+		return new Promise(function(resolve) {
+			setImmediate(resolve);
+		}).then(function() {
+			var status = executor.getStatus();
+			expect(status.queuedCount).toBe(1);
+			expect(status.runningCount).toBe(2);
+			expect(runSpy.calls.length).toBe(2);
+		});
+	});
+
+	it('should run queued jobs as capacity becomes available', function() {
+		var executor = new JobExecutorBuiltin({
+			maxConcurrent: 2
+		}, {});
+
+		var resolveOuter;
+
+		var trackedJobA = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				expect(trackedJobA.run.calls.length).toBe(1);
+				expect(trackedJobB.run.calls.length).toBe(0);
+				expect(trackedJobC.run.calls.length).toBe(0);
+				expect(trackedJobD.run.calls.length).toBe(0);
+
+				var status = executor.getStatus();
+				expect(status.queuedCount).toBe(3);
+				expect(status.runningCount).toBe(1);
+
+				this.promise = new Promise(function(resolve) {
+					setImmediate(function() {
+						this.emit(constants.EVENT_JOB_SUCCESS, {});
+						resolve({});
+					}.bind(this));
+				}.bind(this));
+				return this;
+			})
+		});
+
+		var trackedJobB = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				expect(trackedJobA.run.calls.length).toBe(1);
+				expect(trackedJobB.run.calls.length).toBe(1);
+				expect(trackedJobC.run.calls.length).toBe(0);
+				expect(trackedJobD.run.calls.length).toBe(0);
+
+				var status = executor.getStatus();
+				expect(status.queuedCount).toBe(2);
+				expect(status.runningCount).toBe(2);
+
+				this.promise = new Promise(function(resolve, reject) {
+					setImmediate(function() {
+						this.emit(constants.EVENT_JOB_FAILURE, new Error());
+						reject(new Error());
+					}.bind(this));
+				}.bind(this));
+				return this;
+			})
+		});
+
+		var trackedJobC = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				expect(trackedJobA.run.calls.length).toBe(1);
+				expect(trackedJobB.run.calls.length).toBe(1);
+				expect(trackedJobC.run.calls.length).toBe(1);
+				expect(trackedJobD.run.calls.length).toBe(0);
+
+				var status = executor.getStatus();
+				expect(status.queuedCount).toBe(1);
+				expect(status.runningCount).toBe(1);
+
+				this.promise = new Promise(function(resolve) {
+					setImmediate(function() {
+						this.emit(constants.EVENT_JOB_SUCCESS, {});
+						resolve({});
+
+						setImmediate(resolveOuter);
+					}.bind(this));
+				}.bind(this));
+				return this;
+			})
+		});
+
+		var trackedJobD = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				expect(trackedJobA.run.calls.length).toBe(1);
+				expect(trackedJobB.run.calls.length).toBe(1);
+				expect(trackedJobC.run.calls.length).toBe(1);
+				expect(trackedJobD.run.calls.length).toBe(1);
+
+				var status = executor.getStatus();
+				expect(status.queuedCount).toBe(0);
+				expect(status.runningCount).toBe(2);
+
+				this.promise = new Promise(function(resolve) {
+					setImmediate(function() {
+						this.emit(constants.EVENT_JOB_SUCCESS, {});
+						resolve({});
+
+						setImmediate(resolveOuter);
+					}.bind(this));
+				}.bind(this));
+				return this;
+			})
+		});
+
+		executor.add(trackedJobA);
+		executor.add(trackedJobB);
+		executor.add(trackedJobC);
+		executor.add(trackedJobD);
+
+		expect(trackedJobA.run.calls.length).toBe(0);
+		expect(trackedJobB.run.calls.length).toBe(0);
+		expect(trackedJobC.run.calls.length).toBe(0);
+		expect(trackedJobD.run.calls.length).toBe(0);
+
+		var status = executor.getStatus();
+		expect(status.queuedCount).toBe(4);
+		expect(status.runningCount).toBe(0);
+
+		return new Promise(function(resolve) {
+			resolveOuter = resolve;
+		}).then(function() {
+			expect(trackedJobA.run.calls.length).toBe(1);
+			expect(trackedJobB.run.calls.length).toBe(1);
+			expect(trackedJobC.run.calls.length).toBe(1);
+			expect(trackedJobD.run.calls.length).toBe(1);
+
+			var status = executor.getStatus();
+			expect(status.queuedCount).toBe(0);
+			expect(status.runningCount).toBe(0);
+		});
+	});
+
+	it('should skip already running jobs once reached in the queue', function() {
+		var executor = new JobExecutorBuiltin({
+			maxConcurrent: 2
+		}, {});
+
+		var resolveOuter;
+
+		var trackedJobA = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				var status = executor.getStatus();
+				expect(status.queuedCount).toBe(2);
+				expect(status.runningCount).toBe(1);
+
+				this.promise = new Promise(function(resolve) {
+					setImmediate(function() {
+						this.emit(constants.EVENT_JOB_SUCCESS, {});
+						resolve({});
+
+						setImmediate(resolveOuter);
+					}.bind(this));
+				}.bind(this));
+				return this;
+			})
+		});
+
+		var trackedJobB = createTrackedJobFixture({
+			promise: Promise.resolve(),
+			run: expect.createSpy().andCall(function() {
+				throw new Error('Expected to not be called');
+			})
+		});
+
+		var trackedJobC = createTrackedJobFixture({
+			run: expect.createSpy().andCall(function() {
+				expect(trackedJobC.run.calls.length).toBe(1);
+				this.promise = Promise.resolve();
+				return this;
+			})
+		});
+
+		executor.add(trackedJobA);
+		executor.add(trackedJobB);
+		executor.add(trackedJobC);
+
+		expect(trackedJobA.run.calls.length).toBe(0);
+		expect(trackedJobB.run.calls.length).toBe(0);
+		expect(trackedJobC.run.calls.length).toBe(0);
+
+		trackedJobC.run();
+
+		var status = executor.getStatus();
+		expect(status.queuedCount).toBe(3);
+		expect(status.runningCount).toBe(0);
+
+		return new Promise(function(resolve) {
+			resolveOuter = resolve;
+		}).then(function() {
+			expect(trackedJobA.run.calls.length).toBe(1);
+			expect(trackedJobC.run.calls.length).toBe(1);
+
+			var status = executor.getStatus();
+			expect(status.queuedCount).toBe(0);
+			expect(status.runningCount).toBe(0);
+		});
+	});
+
+	describe('JobExecutorBuiltin.parseOptions', function() {
+		it('should normalize the props', function() {
+			var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+			var parsed = JobExecutorBuiltin.parseOptions({}, defaultOptions);
+			expect(parsed).toBeA('object');
+			expect(Object.keys(parsed).sort()).toEqual(Object.keys(defaultOptions).sort());
+			expect(parsed.maxConcurrent).toBe(0);
+		});
+
+		it('should omit props not in the defaults', function() {
+			var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+			var parsed = JobExecutorBuiltin.parseOptions({
+				someOtherProp: {}
+			}, defaultOptions);
+			expect(parsed).toBeA('object');
+			expect(Object.keys(parsed).sort()).toEqual(Object.keys(defaultOptions).sort());
+		});
+
+		it('should throw a InvalidManagerOptionsError if "maxConcurrent" is not a finite number', function() {
+			expect(function() {
+				var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+				JobExecutorBuiltin.parseOptions({
+					maxConcurrent: false
+				}, defaultOptions);
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorOptions.maxConcurrent'
+			});
+			expect(function() {
+				var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+				JobExecutorBuiltin.parseOptions({
+					maxConcurrent: null
+				}, defaultOptions);
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorOptions.maxConcurrent'
+			});
+			expect(function() {
+				var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+				JobExecutorBuiltin.parseOptions({
+					maxConcurrent: {}
+				}, defaultOptions);
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorOptions.maxConcurrent'
+			});
+			expect(function() {
+				var defaultOptions = JobExecutorBuiltin.getDefaultOptions();
+				JobExecutorBuiltin.parseOptions({
+					maxConcurrent: Infinity
+				}, defaultOptions);
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorOptions.maxConcurrent'
+			});
+		});
+
+		it('should normalize "maxConcurrent" so it is no less than 0', function() {
+			var parsedA = JobExecutorBuiltin.parseOptions({
+				maxConcurrent: -10
+			}, JobExecutorBuiltin.getDefaultOptions());
+			expect(parsedA.maxConcurrent).toBe(0);
+
+			var parsedB = JobExecutorBuiltin.parseOptions({
+				maxConcurrent: 10
+			}, JobExecutorBuiltin.getDefaultOptions());
+			expect(parsedB.maxConcurrent).toBe(10);
+		});
+	});
+});

--- a/test/specs/util.spec.js
+++ b/test/specs/util.spec.js
@@ -7,6 +7,7 @@ var errors = require('../../lib/errors');
 describe('util', function() {
 	var exportNames = [
 		'dehydrateError',
+		'extendDefaultOptions',
 		'getDefaultManagerOptions',
 		'getUniqueKey',
 		'objectValues',
@@ -857,6 +858,59 @@ describe('util', function() {
 
 			var dehydrated = util.dehydrateError(err);
 			expect(Object.keys(dehydrated)).toEqual(['name', 'message', 'stack', 'foo']);
+		});
+	});
+
+	describe('extendDefaultOptions', function() {
+		it('should include the defaults', function() {
+			var defaults = {
+				foo: 500,
+				bar: 300
+			};
+			var parsed = util.extendDefaultOptions({}, defaults);
+			expect(parsed).toBeA('object');
+			expect(Object.keys(parsed)).toEqual(Object.keys(defaults));
+			expect(parsed.foo).toBe(500);
+			expect(parsed.bar).toBe(300);
+		});
+
+		it('should override defaults and maintain same key order as defaults', function() {
+			var defaults = {
+				foo: 500,
+				bar: 200
+			};
+			var parsed = util.extendDefaultOptions({
+				bar: 200,
+				foo: 600
+			}, defaults);
+			expect(Object.keys(parsed)).toEqual(Object.keys(defaults));
+			expect(parsed.foo).toBe(600);
+			expect(parsed.bar).toBe(200);
+		});
+
+		it('should omit override props not in the defaults', function() {
+			var defaults = {
+				foo: 500
+			};
+			var parsed = util.extendDefaultOptions({
+				bar: 200
+			}, defaults);
+			expect(parsed).toBeA('object');
+			expect(Object.keys(parsed)).toEqual(Object.keys(defaults));
+		});
+
+		it('should omit override props that are not "own"', function() {
+			function Super() {
+				expect(this.foo).toBe(200);
+			}
+			Super.prototype.foo = 200;
+
+			var defaults = {
+				foo: 500
+			};
+
+			var parsed = util.extendDefaultOptions(new Super(), defaults);
+			expect(parsed.foo).toBe(500);
 		});
 	});
 });

--- a/test/specs/util.spec.js
+++ b/test/specs/util.spec.js
@@ -27,6 +27,8 @@ describe('util', function() {
 	var managerOptions = [
 		'forkModulePath',
 		'jobsModulePath',
+		'jobExecutorClass',
+		'jobExecutorOptions',
 		'initModulePath',
 		'terminationSIGTERMTimeout',
 		'terminationSIGKILLTimeout',
@@ -46,6 +48,14 @@ describe('util', function() {
 
 		it('should have "jobsModulePath" default to null', function() {
 			expect(util.getDefaultManagerOptions().jobsModulePath).toBe(null);
+		});
+
+		it('should have "jobExecutorClass" default to null', function() {
+			expect(util.getDefaultManagerOptions().jobExecutorClass).toBe(null);
+		});
+
+		it('should have "jobExecutorOptions" default to null', function() {
+			expect(util.getDefaultManagerOptions().jobExecutorOptions).toBe(null);
 		});
 
 		it('should have "terminationSIGTERMTimeout" default to 60000', function() {
@@ -136,6 +146,28 @@ describe('util', function() {
 				}, util.getDefaultManagerOptions());
 			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
 				propName: 'initModulePath'
+			});
+		});
+
+		it('should throw a InvalidManagerOptionsError if "jobExecutorClass" is not a function', function() {
+			expect(function() {
+				util.parseManagerOptions({
+					jobsModulePath: 'path/to/module',
+					jobExecutorClass: {}
+				}, util.getDefaultManagerOptions());
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorClass'
+			});
+		});
+
+		it('should throw a InvalidManagerOptionsError if "jobExecutorOptions" is not a function', function() {
+			expect(function() {
+				util.parseManagerOptions({
+					jobsModulePath: 'path/to/module',
+					jobExecutorOptions: 500
+				}, util.getDefaultManagerOptions());
+			}).toThrowWithProps(errors.InvalidManagerOptionsError, {
+				propName: 'jobExecutorOptions'
 			});
 		});
 

--- a/test/specs/util.spec.js
+++ b/test/specs/util.spec.js
@@ -72,7 +72,7 @@ describe('util', function() {
 				jobsModulePath: 'path/to/worker.js'
 			}, defaultOptions);
 			expect(parsed).toBeA('object');
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(managerOptions);
+			expect(Object.keys(parsed).sort()).toEqual(managerOptions);
 			expect(parsed.jobsModulePath).toBe('path/to/worker.js');
 			expect(parsed.forkModulePath).toBe(defaultOptions.forkModulePath);
 			expect(parsed.initModulePath).toBe(defaultOptions.initModulePath);
@@ -84,7 +84,7 @@ describe('util', function() {
 				someOtherProp: {}
 			}, util.getDefaultManagerOptions());
 			expect(parsed).toBeA('object');
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(managerOptions);
+			expect(Object.keys(parsed).sort()).toEqual(managerOptions);
 		});
 
 		it('should throw a InvalidManagerOptionsError if "jobsModulePath" is not a string', function() {
@@ -216,7 +216,7 @@ describe('util', function() {
 			};
 			var parsed = util.parseJobConfig('FOO', jobConfig);
 			expect(parsed).toBeA(Object);
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(props);
+			expect(Object.keys(parsed).sort()).toEqual(props);
 			expect(parsed.jobName).toBe('FOO');
 			expect(parsed.run).toBe(jobConfig.run);
 			expect(parsed.quickRun).toBe(jobConfig.quickRun);
@@ -233,7 +233,7 @@ describe('util', function() {
 			};
 			var parsed = util.parseJobConfig('FOO', jobConfig);
 			expect(parsed).toBeA(Object);
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(props);
+			expect(Object.keys(parsed).sort()).toEqual(props);
 			expect(parsed.jobName).toBe('FOO');
 			expect(parsed.run).toBe(jobConfig.run);
 			expect(parsed.quickRun).toBe(null);
@@ -263,7 +263,7 @@ describe('util', function() {
 			};
 			var parsed = util.parseJobConfig('FOO', jobConfig);
 			expect(parsed).toBeA(Object);
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(props);
+			expect(Object.keys(parsed).sort()).toEqual(props);
 			expect(parsed.jobName).toBe('FOO');
 			expect(parsed.run).toBe(jobConfig.run);
 			expect(parsed.quickRun).toBe(null);
@@ -276,7 +276,7 @@ describe('util', function() {
 			var jobConfig = function() {};
 			var parsed = util.parseJobConfig('FOO', jobConfig);
 			expect(parsed).toBeA(Object);
-			expect(Object.getOwnPropertyNames(parsed).sort()).toEqual(props);
+			expect(Object.keys(parsed).sort()).toEqual(props);
 			expect(parsed.jobName).toBe('FOO');
 			expect(parsed.run).toBe(jobConfig);
 			expect(parsed.quickRun).toBe(null);


### PR DESCRIPTION
Breaking changes:

* Change HubManager#queueJob to add created TrackedJob instances to HubManager#jobExecutor and no longer call TrackedJob#run. As a result, TrackedJob will be in a pre-run state directly after HubManager#queueJob.

Non-breaking changes:

* Add HubManager#jobExecutor member property which is an instance of a JobExecutor abstract class. TrackedJob instances are added to JobExecutor which is then responsible for calling TrackedJob#run.

* Add `jobExecutorClass` and `jobExecutorOptions` options to HubManagerOptions to specify the constructor to use for HubManager#jobExecutor and the options to pass to the instance.

* Add a built-in implementation of JobExecutor (JobExecutorBuiltin) that optionally allows the number of concurrently running jobs to be limited.

* Add util.extendDefaultOptions for handling "options" defaults/overrides

* Fix "options" tests using Object.getOwnPropertyNames 

Closes #2 