### PR TITLE
Fix misspelled "Middleware" in methods

### DIFF
--- a/.bin/docs/index.js
+++ b/.bin/docs/index.js
@@ -242,7 +242,7 @@ function buildSplit(templateData, options) {
 			if (!templateData.find(function(doclet) {
 				return doclet.kind === 'function' && doclet.category === 'middleware';
 			})) {
-				// Skip middlware file if none were found.
+				// Skip middleware file if none were found.
 				return;
 			}
 

--- a/docs/api-protected/HubManager.md
+++ b/docs/api-protected/HubManager.md
@@ -15,7 +15,7 @@ Manages the lifecycle of jobs.
     * [.jobs](HubManager.md#HubManager+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
     * [.jobExecutor](HubManager.md#HubManager+jobExecutor) : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
     * [.start()](HubManager.md#HubManager+start) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
-    * [.addSyncMiddlware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddlware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
+    * [.addSyncMiddleware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddleware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.getSupportedSyncMiddleware()](HubManager.md#HubManager+getSupportedSyncMiddleware) ⇒ <code>Array.&lt;string&gt;</code>
     * [.getUniqueKey(job, [params])](HubManager.md#HubManager+getUniqueKey) ⇒ <code>string</code> &#124; <code>null</code>
     * [.validateJobParams(job, params)](HubManager.md#HubManager+validateJobParams) ⇒ <code>Promise</code>
@@ -78,12 +78,12 @@ Start the HubManager instance, loading jobs from the module specified by [HubMan
 - <code>[JobAlreadyExistsError](JobAlreadyExistsError.md#JobAlreadyExistsError)</code> 
 - <code>[InvalidJobConfigError](InvalidJobConfigError.md#InvalidJobConfigError)</code> 
 
-<a name="HubManager+addSyncMiddlware"></a>
+<a name="HubManager+addSyncMiddleware"></a>
 
-### hubManager.addSyncMiddlware(type, middleware, [priority]) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
+### hubManager.addSyncMiddleware(type, middleware, [priority]) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
 Add a sync middleware.
 
-Shortcut for `hubManager.middleware.addSyncMiddlware` that allows chaining.
+Shortcut for `hubManager.middleware.addSyncMiddleware` that allows chaining.
 
 **Kind**: instance method of <code>[HubManager](HubManager.md#HubManager)</code>  
 **Throws**:

--- a/docs/api-protected/MiddlewareStore.md
+++ b/docs/api-protected/MiddlewareStore.md
@@ -10,14 +10,14 @@ Plugins to customize functionality of jobhub.
 * [MiddlewareStore](MiddlewareStore.md#MiddlewareStore)
     * [.addSupportedSyncTypes(types)](MiddlewareStore.md#MiddlewareStore+addSupportedSyncTypes) ⇒ <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
     * [.addSupportedAsyncTypes(types)](MiddlewareStore.md#MiddlewareStore+addSupportedAsyncTypes) ⇒ <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
-    * [.addSyncMiddlware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addSyncMiddlware)
-    * [.addAsyncMiddlware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addAsyncMiddlware)
+    * [.addSyncMiddleware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addSyncMiddleware)
+    * [.addAsyncMiddleware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addAsyncMiddleware)
     * [.hasSyncSupport(type)](MiddlewareStore.md#MiddlewareStore+hasSyncSupport) ⇒ <code>boolean</code>
     * [.hasAsyncSupport(type)](MiddlewareStore.md#MiddlewareStore+hasAsyncSupport) ⇒ <code>boolean</code>
     * [.getSupportedSyncTypes()](MiddlewareStore.md#MiddlewareStore+getSupportedSyncTypes) ⇒ <code>Array.&lt;string&gt;</code>
     * [.getSupportedAsyncTypes()](MiddlewareStore.md#MiddlewareStore+getSupportedAsyncTypes) ⇒ <code>Array.&lt;string&gt;</code>
-    * [.removeSyncMiddlware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeSyncMiddlware)
-    * [.removeAsyncMiddlware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeAsyncMiddlware)
+    * [.removeSyncMiddleware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeSyncMiddleware)
+    * [.removeAsyncMiddleware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeAsyncMiddleware)
     * [.runSyncMiddleware(type, context, args, next)](MiddlewareStore.md#MiddlewareStore+runSyncMiddleware) ⇒ <code>\*</code>
     * [.runAsyncMiddleware(type, context, args, next)](MiddlewareStore.md#MiddlewareStore+runAsyncMiddleware) ⇒ <code>Promise</code>
 
@@ -43,9 +43,9 @@ Add supported async middleware types.
 | --- | --- |
 | types | <code>Array.&lt;string&gt;</code> | 
 
-<a name="MiddlewareStore+addSyncMiddlware"></a>
+<a name="MiddlewareStore+addSyncMiddleware"></a>
 
-### middlewareStore.addSyncMiddlware(type, middleware, [priority])
+### middlewareStore.addSyncMiddleware(type, middleware, [priority])
 Add a sync middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -60,9 +60,9 @@ Add a sync middleware.
 | middleware | <code>function</code> |  | 
 | [priority] | <code>number</code> | <code>100</code> | 
 
-<a name="MiddlewareStore+addAsyncMiddlware"></a>
+<a name="MiddlewareStore+addAsyncMiddleware"></a>
 
-### middlewareStore.addAsyncMiddlware(type, middleware, [priority])
+### middlewareStore.addAsyncMiddleware(type, middleware, [priority])
 Add an async middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -111,9 +111,9 @@ Get list of supported sync middleware types.
 Get list of supported async middleware types.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
-<a name="MiddlewareStore+removeSyncMiddlware"></a>
+<a name="MiddlewareStore+removeSyncMiddleware"></a>
 
-### middlewareStore.removeSyncMiddlware(type, middleware)
+### middlewareStore.removeSyncMiddleware(type, middleware)
 Remove a sync middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -127,9 +127,9 @@ Remove a sync middleware.
 | type | <code>string</code> | 
 | middleware | <code>function</code> | 
 
-<a name="MiddlewareStore+removeAsyncMiddlware"></a>
+<a name="MiddlewareStore+removeAsyncMiddleware"></a>
 
-### middlewareStore.removeAsyncMiddlware(type, middleware)
+### middlewareStore.removeAsyncMiddleware(type, middleware)
 Remove an async middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  

--- a/docs/api-protected/middleware.md
+++ b/docs/api-protected/middleware.md
@@ -168,7 +168,7 @@ Intercepts creation of args provided to [forkJobProcess](middleware.md#forkJobPr
 hub.addSyncMiddleware('buildForkArgs', function(trackedJob, next) {
     return next().concat([
         '--my-custom-flag'
-    ];
+    ]);
 });
 ```
 <a name="buildForkOpts"></a>
@@ -190,10 +190,10 @@ Intercepts creation of opts provided to [forkJobProcess](middleware.md#forkJobPr
 ```javascript
 hub.addSyncMiddleware('buildForkOpts', function(trackedJob, next) {
     return Object.assign(next(), {
-        env: [
+        env: {
             CUSTOM_ENV: 'my-value'
-        ]
-    ];
+        }
+    });
 });
 ```
 <a name="createWorkerMediator"></a>

--- a/docs/api/HubManager.md
+++ b/docs/api/HubManager.md
@@ -15,7 +15,7 @@ Manages the lifecycle of jobs.
     * [.jobs](HubManager.md#HubManager+jobs) : <code>[JobConfigStore](JobConfigStore.md#JobConfigStore)</code>
     * [.jobExecutor](HubManager.md#HubManager+jobExecutor) : <code>[JobExecutor](JobExecutor.md#JobExecutor)</code>
     * [.start()](HubManager.md#HubManager+start) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
-    * [.addSyncMiddlware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddlware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
+    * [.addSyncMiddleware(type, middleware, [priority])](HubManager.md#HubManager+addSyncMiddleware) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
     * [.getUniqueKey(job, [params])](HubManager.md#HubManager+getUniqueKey) ⇒ <code>string</code> &#124; <code>null</code>
     * [.validateJobParams(job, params)](HubManager.md#HubManager+validateJobParams) ⇒ <code>Promise</code>
     * [.getTrackedJob(jobId)](HubManager.md#HubManager+getTrackedJob) ⇒ <code>[TrackedJob](TrackedJob.md#TrackedJob)</code> &#124; <code>null</code>
@@ -75,12 +75,12 @@ Start the HubManager instance, loading jobs from the module specified by [HubMan
 - <code>[JobAlreadyExistsError](JobAlreadyExistsError.md#JobAlreadyExistsError)</code> 
 - <code>[InvalidJobConfigError](InvalidJobConfigError.md#InvalidJobConfigError)</code> 
 
-<a name="HubManager+addSyncMiddlware"></a>
+<a name="HubManager+addSyncMiddleware"></a>
 
-### hubManager.addSyncMiddlware(type, middleware, [priority]) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
+### hubManager.addSyncMiddleware(type, middleware, [priority]) ⇒ <code>[HubManager](HubManager.md#HubManager)</code>
 Add a sync middleware.
 
-Shortcut for `hubManager.middleware.addSyncMiddlware` that allows chaining.
+Shortcut for `hubManager.middleware.addSyncMiddleware` that allows chaining.
 
 **Kind**: instance method of <code>[HubManager](HubManager.md#HubManager)</code>  
 **Throws**:

--- a/docs/api/MiddlewareStore.md
+++ b/docs/api/MiddlewareStore.md
@@ -10,14 +10,14 @@ Plugins to customize functionality of jobhub.
 * [MiddlewareStore](MiddlewareStore.md#MiddlewareStore)
     * [.addSupportedSyncTypes(types)](MiddlewareStore.md#MiddlewareStore+addSupportedSyncTypes) ⇒ <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
     * [.addSupportedAsyncTypes(types)](MiddlewareStore.md#MiddlewareStore+addSupportedAsyncTypes) ⇒ <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>
-    * [.addSyncMiddlware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addSyncMiddlware)
-    * [.addAsyncMiddlware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addAsyncMiddlware)
+    * [.addSyncMiddleware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addSyncMiddleware)
+    * [.addAsyncMiddleware(type, middleware, [priority])](MiddlewareStore.md#MiddlewareStore+addAsyncMiddleware)
     * [.hasSyncSupport(type)](MiddlewareStore.md#MiddlewareStore+hasSyncSupport) ⇒ <code>boolean</code>
     * [.hasAsyncSupport(type)](MiddlewareStore.md#MiddlewareStore+hasAsyncSupport) ⇒ <code>boolean</code>
     * [.getSupportedSyncTypes()](MiddlewareStore.md#MiddlewareStore+getSupportedSyncTypes) ⇒ <code>Array.&lt;string&gt;</code>
     * [.getSupportedAsyncTypes()](MiddlewareStore.md#MiddlewareStore+getSupportedAsyncTypes) ⇒ <code>Array.&lt;string&gt;</code>
-    * [.removeSyncMiddlware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeSyncMiddlware)
-    * [.removeAsyncMiddlware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeAsyncMiddlware)
+    * [.removeSyncMiddleware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeSyncMiddleware)
+    * [.removeAsyncMiddleware(type, middleware)](MiddlewareStore.md#MiddlewareStore+removeAsyncMiddleware)
     * [.runSyncMiddleware(type, context, args, next)](MiddlewareStore.md#MiddlewareStore+runSyncMiddleware) ⇒ <code>\*</code>
     * [.runAsyncMiddleware(type, context, args, next)](MiddlewareStore.md#MiddlewareStore+runAsyncMiddleware) ⇒ <code>Promise</code>
 
@@ -43,9 +43,9 @@ Add supported async middleware types.
 | --- | --- |
 | types | <code>Array.&lt;string&gt;</code> | 
 
-<a name="MiddlewareStore+addSyncMiddlware"></a>
+<a name="MiddlewareStore+addSyncMiddleware"></a>
 
-### middlewareStore.addSyncMiddlware(type, middleware, [priority])
+### middlewareStore.addSyncMiddleware(type, middleware, [priority])
 Add a sync middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -60,9 +60,9 @@ Add a sync middleware.
 | middleware | <code>function</code> |  | 
 | [priority] | <code>number</code> | <code>100</code> | 
 
-<a name="MiddlewareStore+addAsyncMiddlware"></a>
+<a name="MiddlewareStore+addAsyncMiddleware"></a>
 
-### middlewareStore.addAsyncMiddlware(type, middleware, [priority])
+### middlewareStore.addAsyncMiddleware(type, middleware, [priority])
 Add an async middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -111,9 +111,9 @@ Get list of supported sync middleware types.
 Get list of supported async middleware types.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
-<a name="MiddlewareStore+removeSyncMiddlware"></a>
+<a name="MiddlewareStore+removeSyncMiddleware"></a>
 
-### middlewareStore.removeSyncMiddlware(type, middleware)
+### middlewareStore.removeSyncMiddleware(type, middleware)
 Remove a sync middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  
@@ -127,9 +127,9 @@ Remove a sync middleware.
 | type | <code>string</code> | 
 | middleware | <code>function</code> | 
 
-<a name="MiddlewareStore+removeAsyncMiddlware"></a>
+<a name="MiddlewareStore+removeAsyncMiddleware"></a>
 
-### middlewareStore.removeAsyncMiddlware(type, middleware)
+### middlewareStore.removeAsyncMiddleware(type, middleware)
 Remove an async middleware.
 
 **Kind**: instance method of <code>[MiddlewareStore](MiddlewareStore.md#MiddlewareStore)</code>  

--- a/lib/HubManager.js
+++ b/lib/HubManager.js
@@ -182,7 +182,7 @@ HubManager.prototype.start = function() {
 /**
  * Add a sync middleware.
  *
- * Shortcut for `hubManager.middleware.addSyncMiddlware` that allows chaining.
+ * Shortcut for `hubManager.middleware.addSyncMiddleware` that allows chaining.
  *
  * @param {string} type
  * @param {function} middleware
@@ -190,8 +190,8 @@ HubManager.prototype.start = function() {
  * @returns {HubManager}
  * @throws {UnsupportedMiddlewareTypeError}
  */
-HubManager.prototype.addSyncMiddlware = function(type, middleware, priority) {
-	this.middleware.addSyncMiddlware(type, middleware, priority);
+HubManager.prototype.addSyncMiddleware = function(type, middleware, priority) {
+	this.middleware.addSyncMiddleware(type, middleware, priority);
 	return this;
 };
 

--- a/lib/JobWorkerIPCMediator.js
+++ b/lib/JobWorkerIPCMediator.js
@@ -319,7 +319,7 @@ JobWorkerIPCMediator.prototype.sendAbortMessage = function() {
  * hub.addSyncMiddleware('buildForkArgs', function(trackedJob, next) {
  *     return next().concat([
  *         '--my-custom-flag'
- *     ];
+ *     ]);
  * });
  * ```
  */
@@ -338,10 +338,10 @@ JobWorkerIPCMediator.prototype.sendAbortMessage = function() {
  * ```javascript
  * hub.addSyncMiddleware('buildForkOpts', function(trackedJob, next) {
  *     return Object.assign(next(), {
- *         env: [
+ *         env: {
  *             CUSTOM_ENV: 'my-value'
- *         ]
- *     ];
+ *         }
+ *     });
  * });
  * ```
  */

--- a/lib/MiddlewareStore.js
+++ b/lib/MiddlewareStore.js
@@ -52,7 +52,7 @@ MiddlewareStore.prototype.addSupportedAsyncTypes = function(types) {
  * @param {number} [priority=100]
  * @throws {UnsupportedMiddlewareTypeError}
  */
-MiddlewareStore.prototype.addSyncMiddlware = function(type, middleware, priority) {
+MiddlewareStore.prototype.addSyncMiddleware = function(type, middleware, priority) {
 	var list = this._syncMiddleware[type];
 	if (!list) {
 		throw new errors.UnsupportedMiddlewareTypeError(false, type);
@@ -69,7 +69,7 @@ MiddlewareStore.prototype.addSyncMiddlware = function(type, middleware, priority
  * @param {number} [priority=100]
  * @throws {UnsupportedMiddlewareTypeError}
  */
-MiddlewareStore.prototype.addAsyncMiddlware = function(type, middleware, priority) {
+MiddlewareStore.prototype.addAsyncMiddleware = function(type, middleware, priority) {
 	var list = this._asyncMiddleware[type];
 	if (!list) {
 		throw new errors.UnsupportedMiddlewareTypeError(true, type);
@@ -123,7 +123,7 @@ MiddlewareStore.prototype.getSupportedAsyncTypes = function() {
  * @param {function} middleware
  * @throws {UnsupportedMiddlewareTypeError}
  */
-MiddlewareStore.prototype.removeSyncMiddlware = function(type, middleware) {
+MiddlewareStore.prototype.removeSyncMiddleware = function(type, middleware) {
 	var list = this._syncMiddleware[type];
 	if (!list) {
 		throw new errors.UnsupportedMiddlewareTypeError(false, type);
@@ -139,7 +139,7 @@ MiddlewareStore.prototype.removeSyncMiddlware = function(type, middleware) {
  * @param {function} middleware
  * @throws {UnsupportedMiddlewareTypeError}
  */
-MiddlewareStore.prototype.removeAsyncMiddlware = function(type, middleware) {
+MiddlewareStore.prototype.removeAsyncMiddleware = function(type, middleware) {
 	var list = this._asyncMiddleware[type];
 	if (!list) {
 		throw new errors.UnsupportedMiddlewareTypeError(true, type);

--- a/test/specs/HubManager.spec.js
+++ b/test/specs/HubManager.spec.js
@@ -179,7 +179,7 @@ describe('HubManager', function() {
 			return origRet;
 		});
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			spyLoadJobsMiddleware
 		);
@@ -195,7 +195,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJobs({
@@ -253,7 +253,7 @@ describe('HubManager', function() {
 		};
 
 		var manager = new HubManager(options);
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				// Register no jobs
@@ -280,7 +280,7 @@ describe('HubManager', function() {
 		};
 
 		var manager = new HubManager(options);
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -314,7 +314,7 @@ describe('HubManager', function() {
 		};
 
 		var manager = new HubManager(options);
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJobs({
@@ -402,7 +402,7 @@ describe('HubManager', function() {
 		};
 
 		var manager = new HubManager(options);
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				// Register no jobs
@@ -425,7 +425,7 @@ describe('HubManager', function() {
 		};
 
 		var manager = new HubManager(options);
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				// Register no jobs
@@ -469,7 +469,7 @@ describe('HubManager', function() {
 			expect(arguments[0]).toBe(trackedJob);
 		});
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -484,7 +484,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				expect(this).toBe(manager);
@@ -540,7 +540,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -554,7 +554,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				var trackedJob = arguments[3](); // Next
@@ -586,7 +586,7 @@ describe('HubManager', function() {
 
 		var trackedJob;
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -597,7 +597,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				trackedJob = arguments[3](); // Next
@@ -629,7 +629,7 @@ describe('HubManager', function() {
 
 		var trackedJob;
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -641,7 +641,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				trackedJob = arguments[3](); // Next
@@ -669,7 +669,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -683,7 +683,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				var trackedJob = arguments[3](); // Next
@@ -726,7 +726,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -747,7 +747,7 @@ describe('HubManager', function() {
 			}
 		);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_JOB,
 			function() {
 				var trackedJob = arguments[3](); // Next
@@ -786,7 +786,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -817,7 +817,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {
@@ -856,7 +856,7 @@ describe('HubManager', function() {
 
 		var manager = new HubManager(options);
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_LOAD_JOBS,
 			function(jobStore) {
 				jobStore.registerJob('foo', {

--- a/test/specs/JobWorker.spec.js
+++ b/test/specs/JobWorker.spec.js
@@ -230,7 +230,7 @@ describe('JobWorker', function() {
 				expect(worker.jobs.registerJobs.calls[0].arguments[0]).toBe(jobsModule);
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				spyWorkerLoadJob
 			);
@@ -255,7 +255,7 @@ describe('JobWorker', function() {
 
 			expect.spyOn(worker.jobs, 'registerJobs');
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function() {
 					throw expectedError;
@@ -379,7 +379,7 @@ describe('JobWorker', function() {
 				return expectedRet;
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_BUILD_JOB_ARG,
 				spyWorkerBuildJobArg
 			);
@@ -436,7 +436,7 @@ describe('JobWorker', function() {
 
 			expect.spyOn(worker, 'init').andCallThrough();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function() {
 					// Do not load jobs
@@ -482,7 +482,7 @@ describe('JobWorker', function() {
 
 			var spyRun = expect.createSpy();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -520,7 +520,7 @@ describe('JobWorker', function() {
 
 			var spyRun = expect.createSpy();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -567,7 +567,7 @@ describe('JobWorker', function() {
 				jobArg.resolve(expectedResult);
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -578,7 +578,7 @@ describe('JobWorker', function() {
 				}
 			);
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_BUILD_JOB_ARG,
 				spyBuildJobArg
 			);
@@ -599,7 +599,7 @@ describe('JobWorker', function() {
 
 			var spyRun = expect.createSpy();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -608,7 +608,7 @@ describe('JobWorker', function() {
 				}
 			);
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_BUILD_JOB_ARG,
 				function() {
 					throw expectedError;
@@ -637,7 +637,7 @@ describe('JobWorker', function() {
 				throw expectedError;
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -664,7 +664,7 @@ describe('JobWorker', function() {
 				jobsModulePath: path.join(__dirname, '../fixtures/jobs.js')
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -691,7 +691,7 @@ describe('JobWorker', function() {
 				job.reject(expectedError);
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -726,7 +726,7 @@ describe('JobWorker', function() {
 				return Promise.resolve();
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -772,7 +772,7 @@ describe('JobWorker', function() {
 				return origRet.then(spyHandleSuccessPromise);
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -805,7 +805,7 @@ describe('JobWorker', function() {
 
 			var promise = worker.start();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function() {
 					throw expectedError;
@@ -861,7 +861,7 @@ describe('JobWorker', function() {
 				return Promise.reject(expectedError);
 			});
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function(jobStore, jobName) {
 					jobStore.registerJob(jobName, {
@@ -895,7 +895,7 @@ describe('JobWorker', function() {
 
 			var promise = worker.start();
 
-			worker.middleware.addSyncMiddlware(
+			worker.middleware.addSyncMiddleware(
 				constants.MIDDLEWARE_WORKER_LOAD_JOB,
 				function() {
 					throw expectedOrigError;

--- a/test/specs/JobWorkerIPCMediator.spec.js
+++ b/test/specs/JobWorkerIPCMediator.spec.js
@@ -141,17 +141,17 @@ describe('JobWorkerIPCMediator', function() {
 			return childProcess = createChildProcessFixture();
 		});
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_BUILD_FORK_ARGS,
 			spyArgs
 		);
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_BUILD_FORK_OPTS,
 			spyOpts
 		);
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_FORK_JOB_PROCESS,
 			spyFork
 		);
@@ -624,7 +624,7 @@ describe('JobWorkerIPCMediator', function() {
 
 		var mediator = new JobWorkerIPCMediator(trackedJob);
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_FORK_JOB_PROCESS,
 			function() {
 				return childProcess;
@@ -669,7 +669,7 @@ describe('JobWorkerIPCMediator', function() {
 
 		var mediator = new JobWorkerIPCMediator(trackedJob);
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_FORK_JOB_PROCESS,
 			function() {
 				return childProcess;
@@ -708,7 +708,7 @@ describe('JobWorkerIPCMediator', function() {
 
 		var mediator = new JobWorkerIPCMediator(trackedJob);
 
-		trackedJob.manager.middleware.addSyncMiddlware(
+		trackedJob.manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_FORK_JOB_PROCESS,
 			function() {
 				return childProcess;

--- a/test/specs/MiddlewareStore.spec.js
+++ b/test/specs/MiddlewareStore.spec.js
@@ -28,14 +28,14 @@ describe('MiddlewareStore', function() {
 
 	it('should throw error if adding middleware without adding support', function() {
 		expect(function() {
-			new MiddlewareStore().addSyncMiddlware('FOO', function(){});
+			new MiddlewareStore().addSyncMiddleware('FOO', function(){});
 		}).toThrowWithProps(errors.UnsupportedMiddlewareTypeError, {
 			isAsync: false,
 			type: 'FOO'
 		});
 
 		expect(function() {
-			new MiddlewareStore().addAsyncMiddlware('FOO', function(){});
+			new MiddlewareStore().addAsyncMiddleware('FOO', function(){});
 		}).toThrowWithProps(errors.UnsupportedMiddlewareTypeError, {
 			isAsync: true,
 			type: 'FOO'
@@ -179,8 +179,8 @@ describe('MiddlewareStore', function() {
 		});
 
 		store.addSupportedSyncTypes(['FOO']);
-		store.addSyncMiddlware('FOO', spyA);
-		store.addSyncMiddlware('FOO', spyB);
+		store.addSyncMiddleware('FOO', spyA);
+		store.addSyncMiddleware('FOO', spyB);
 
 		var ret = store.runSyncMiddleware('FOO', ctx, args, spyLast);
 		expect(ret).toBe('BAR');
@@ -269,8 +269,8 @@ describe('MiddlewareStore', function() {
 		});
 
 		store.addSupportedAsyncTypes(['FOO']);
-		store.addAsyncMiddlware('FOO', spyA);
-		store.addAsyncMiddlware('FOO', spyB);
+		store.addAsyncMiddleware('FOO', spyA);
+		store.addAsyncMiddleware('FOO', spyB);
 
 		var promise = store.runAsyncMiddleware('FOO', ctx, args, spyLast);
 		expect(promise).toBeA(Promise);
@@ -308,8 +308,8 @@ describe('MiddlewareStore', function() {
 		var spyLast = expect.createSpy().andReturn('BAR');
 
 		store.addSupportedSyncTypes(['FOO']);
-		store.addSyncMiddlware('FOO', spyA);
-		store.addSyncMiddlware('FOO', spyB);
+		store.addSyncMiddleware('FOO', spyA);
+		store.addSyncMiddleware('FOO', spyB);
 		var ret = store.runSyncMiddleware('FOO', ctx, args, spyLast);
 
 		expect(ret).toBe('500A');
@@ -337,8 +337,8 @@ describe('MiddlewareStore', function() {
 		var spyLast = expect.createSpy().andReturn('BAR');
 
 		store.addSupportedAsyncTypes(['FOO']);
-		store.addAsyncMiddlware('FOO', spyA);
-		store.addAsyncMiddlware('FOO', spyB);
+		store.addAsyncMiddleware('FOO', spyA);
+		store.addAsyncMiddleware('FOO', spyB);
 
 		var promise = store.runAsyncMiddleware('FOO', ctx, args, spyLast);
 		return promise.then(function(result) {
@@ -359,8 +359,8 @@ describe('MiddlewareStore', function() {
 		var spyLast = expect.createSpy().andReturn('BAR');
 
 		store.addSupportedSyncTypes(['FOO']);
-		store.addSyncMiddlware('FOO', spyA);
-		store.removeSyncMiddlware('FOO', spyA);
+		store.addSyncMiddleware('FOO', spyA);
+		store.removeSyncMiddleware('FOO', spyA);
 		store.runSyncMiddleware('FOO', ctx, args, spyLast);
 
 		expect(spyA.calls.length).toBe(0);
@@ -377,8 +377,8 @@ describe('MiddlewareStore', function() {
 		var spyLast = expect.createSpy().andReturn('BAR');
 
 		store.addSupportedAsyncTypes(['FOO']);
-		store.addAsyncMiddlware('FOO', spyA);
-		store.removeAsyncMiddlware('FOO', spyA);
+		store.addAsyncMiddleware('FOO', spyA);
+		store.removeAsyncMiddleware('FOO', spyA);
 
 		var promise = store.runAsyncMiddleware('FOO', ctx, args, spyLast);
 		return promise.then(function(result) {
@@ -416,8 +416,8 @@ describe('MiddlewareStore', function() {
 		});
 
 		store.addSupportedSyncTypes(['FOO']);
-		store.addSyncMiddlware('FOO', spyB, 100);
-		store.addSyncMiddlware('FOO', spyA, 10);
+		store.addSyncMiddleware('FOO', spyB, 100);
+		store.addSyncMiddleware('FOO', spyA, 10);
 		store.runSyncMiddleware('FOO', ctx, args, spyLast);
 		expect(spyA.calls.length).toBe(1);
 		expect(spyB.calls.length).toBe(1);
@@ -452,8 +452,8 @@ describe('MiddlewareStore', function() {
 		});
 
 		store.addSupportedAsyncTypes(['FOO']);
-		store.addAsyncMiddlware('FOO', spyB, 100);
-		store.addAsyncMiddlware('FOO', spyA, 10);
+		store.addAsyncMiddleware('FOO', spyB, 100);
+		store.addAsyncMiddleware('FOO', spyA, 10);
 
 		var promise = store.runAsyncMiddleware('FOO', ctx, args, spyLast);
 		return promise.then(function(result) {
@@ -504,9 +504,9 @@ describe('MiddlewareStore', function() {
 		});
 
 		store.addSupportedSyncTypes(['FOO']);
-		store.addSyncMiddlware('FOO', spyB);
-		store.addSyncMiddlware('FOO', spyC, 100.0000001);
-		store.addSyncMiddlware('FOO', spyA, 100 - .000001);
+		store.addSyncMiddleware('FOO', spyB);
+		store.addSyncMiddleware('FOO', spyC, 100.0000001);
+		store.addSyncMiddleware('FOO', spyA, 100 - .000001);
 		store.runSyncMiddleware('FOO', ctx, args, spyLast);
 		expect(spyA.calls.length).toBe(1);
 		expect(spyB.calls.length).toBe(1);
@@ -558,9 +558,9 @@ describe('MiddlewareStore', function() {
 		spyLast.namex = 'spyLast';
 
 		store.addSupportedAsyncTypes(['FOO']);
-		store.addAsyncMiddlware('FOO', spyB);
-		store.addAsyncMiddlware('FOO', spyC, 100.0000001);
-		store.addAsyncMiddlware('FOO', spyA, 100 - .000001);
+		store.addAsyncMiddleware('FOO', spyB);
+		store.addAsyncMiddleware('FOO', spyC, 100.0000001);
+		store.addAsyncMiddleware('FOO', spyA, 100 - .000001);
 
 		var promise = store.runAsyncMiddleware('FOO', ctx, args, spyLast);
 		return promise.then(function(result) {

--- a/test/specs/TrackedJob.spec.js
+++ b/test/specs/TrackedJob.spec.js
@@ -1011,7 +1011,7 @@ describe('TrackedJob', function() {
 				return workerMediator;
 			});
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			spyCreateMediator
 		);
@@ -1048,7 +1048,7 @@ describe('TrackedJob', function() {
 		var manager = createManagerFixture();
 		var expectedError = new Error();
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1093,7 +1093,7 @@ describe('TrackedJob', function() {
 		var manager = createManagerFixture();
 		var expectedResult = {};
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1141,7 +1141,7 @@ describe('TrackedJob', function() {
 		var manager = createManagerFixture();
 		var expectedError = new Error();
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1181,7 +1181,7 @@ describe('TrackedJob', function() {
 		var manager = createManagerFixture();
 		var expectedResult = {};
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1220,7 +1220,7 @@ describe('TrackedJob', function() {
 		var manager = createManagerFixture();
 		var expectedError = new Error();
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1264,7 +1264,7 @@ describe('TrackedJob', function() {
 	it('should send abort message after worker forked', function() {
 		var manager = createManagerFixture();
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {
@@ -1378,7 +1378,7 @@ describe('TrackedJob', function() {
 		var progressObj = {};
 		var manager = createManagerFixture();
 
-		manager.middleware.addSyncMiddlware(
+		manager.middleware.addSyncMiddleware(
 			constants.MIDDLEWARE_CREATE_WORKER_MEDIATOR,
 			function() {
 				return createJobWorkerMediatorFixture(this, {


### PR DESCRIPTION
* Fix `HubManager#addSyncMiddleware` misspelled as `addSyncMiddlware`
* Fix `MiddlewareStore#addSyncMiddleware` misspelled as `addSyncMiddlware`
* Fix `MiddlewareStore#addAsyncMiddleware` misspelled as `addAsyncMiddlware`
* Fix `MiddlewareStore#removeSyncMiddleware` misspelled as `removeSyncMiddlware`
* Fix `MiddlewareStore#removeAsyncMiddleware` misspelled as `removeAsyncMiddlware`
* Fix syntax errors in middleware JSDoc examples

Fixes #6